### PR TITLE
CDAP-16305 fix primary key updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <delta.version>0.1.0-SNAPSHOT</delta.version>
     <failsafe.version>2.3.3</failsafe.version>
     <gcs.version>1.78.0</gcs.version>
+    <logback.version>1.2.3</logback.version>
   </properties>
 
   <repositories>
@@ -109,6 +110,12 @@
       <groupId>net.jodah</groupId>
       <artifactId>failsafe</artifactId>
       <version>${failsafe.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -19,6 +19,8 @@ package io.cdap.delta.bigquery;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.FieldValue;
+import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobId;
@@ -30,6 +32,7 @@ import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
@@ -37,7 +40,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.delta.api.DDLEvent;
 import io.cdap.delta.api.DMLEvent;
-import io.cdap.delta.api.DMLOperation;
 import io.cdap.delta.api.DeltaFailureException;
 import io.cdap.delta.api.DeltaTargetContext;
 import io.cdap.delta.api.EventConsumer;
@@ -58,7 +60,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -70,23 +76,20 @@ import java.util.stream.Collectors;
  *
  * Writes to BigQuery in three steps.
  *
- * Step 1 - Write a batch of changes to GCS exactly once
+ * Step 1 - Write a batch of changes to GCS
  *
  * Each batch of changes is written to GCS as an object with path:
  *
  *   [staging bucket]/cdap/cdc/[app name]/[table id]/[batch id]
  *
+ * Batch id is the timestamp that the first event in the batch was processed.
  * The size of the batch is determined through configuration.
  * There is a maximum number of rows to include in each batch and a maximum amount of time to wait in between batches.
- * If the incoming events contain a transaction id, the maximums will be ignored in favor of including all events from
- * the same transaction in the same batch. The assumption is that events for the same transaction will be applied
- * in order, with no events from other transactions interleaved in between.
  * Each object is written in avro format and contains the columns in the destination table plus two additional columns:
  *   _op: CREATE | UPDATE | DELETE
  *   _batch_id: the batch id
  *
  * Changes in the batch do not span across a DDL event, so they are guaranteed to conform to the same schema.
- * Once the object is successfully written, the offset of the latest DMLEvent within the batch is persisted.
  * Failure scenarios are:
  *
  *   1. The program dies after the object is written, but before the offset is persisted.
@@ -100,23 +103,17 @@ import java.util.stream.Collectors;
  *      there was a temporary outage, etc. In this scenario, the write will be repeatedly retried until it
  *      succeeds. It may need manual intervention to succeed.
  *
- *
- * Step 2 - Load data from GCS into staging BigQuery table exactly once
+ * Step 2 - Load data from GCS into staging BigQuery table
  *
  * This step happens after the offset from Step 1 is successfully persisted. This will load the object
  * into a staging table in BigQuery. The staging table has the same schema as the rows in the GCS object.
- * It is clustered on _batch_id.
- * The job id for the load is of the form [app name]_stage_[batch id]_[retry num].
+ * It is clustered on _batch_id in order to make reads and deletes on the _batch_id efficient.
+ * The job id for the load is of the form [app name]_stage_[dataset]_[table]_[batch id]_[retry num].
  * Failure scenarios are:
  *
  *   1. The load job fails for some reason. For example, permissions were revoked, quota was hit, temporary outage, etc.
  *      The load will be repeatedly retried until is succeeds. It may need manual intervention to succeed.
- *   2. The program dies. When the program starts up again, batches are found in the staging directory on GCS.
- *      The batches are checked in order of their write time. For each batch, the consumer will check if a
- *      corresponding BigQuery job exists. If not, it will create a load job and continue as normal. If the job
- *      exists and it is still running, it will wait for it to finish. If the job exists and it failed, the consumer
- *      will look for retry jobs. If all retry jobs have failed, it will continue retrying.
- *
+ *   2. The program dies. When the program starts up again, events will be replayed from the last committed offset.
  *
  * Step 3 - Merge a batch of data from the staging BigQuery table into the target table
  *
@@ -133,22 +130,18 @@ import java.util.stream.Collectors;
  *     INSERT(...)
  *     VALUES(...)
  *
- * The job id is of the form [app name]_merge_staging_[batch id]_[retry_num].
+ * The job id is of the form [app name]_merge_[dataset]_[table]_[batch id]_[retry_num].
  * This query ensures that it does not matter if there are duplicate events in the batch objects on GCS.
  * Duplicate inserts and deletes will not match and be ignored.
  * Duplicate updates will update the target row to be the same that it already is.
- * Once the job succeeds, the corresponding GCS object is deleted. Failure scenarios are:
+ * Once the job succeeds, the corresponding GCS object is deleted and the offset of the latest event is committed.
+ * Failure scenarios are:
  *
  *   1. The merge query fails for some reason. The consumer will retry until it succeeds.
  *      It may need manual intervention to succeed.
- *   2. The program dies. When the program starts up again, batch are found in the staging directory on GCS.
- *      BigQuery jobs are listed to determine which state the program was in before it died.
- *        a. No merge job for the batch is found. The consumer creates the merge job and continues normally.
- *        b. The merge job for the batch is found and successful. The consumer deletes the GCS object and continues
- *           normally.
- *        c. A running merge job for the batch is found. The consumer waits for it to finish and continues normally.
- *        d. A merge job for the batch is found that has failed. The consumer retries the job until it succeeds.
- *   3. The GCS delete fails. The consumer keeps retrying until it succeeds.
+ *   2. The program dies. Events are replayed from the last committed offset when the program starts back up.
+ *   3. The GCS delete fails. The error is logged, but the consumer proceeds on.
+ *      Manual deletion of the object is required.
  *
  */
 public class BigQueryEventConsumer implements EventConsumer {
@@ -161,6 +154,8 @@ public class BigQueryEventConsumer implements EventConsumer {
   private final Bucket bucket;
   private final String project;
   private final RetryPolicy<Object> commitRetryPolicy;
+  private final Map<TableId, Long> latestSeenSequence;
+  private final Map<TableId, Long> latestMergedSequence;
   private ScheduledExecutorService executorService;
   private ScheduledFuture<?> scheduledFlush;
   private Offset latestOffset;
@@ -172,8 +167,8 @@ public class BigQueryEventConsumer implements EventConsumer {
   // cannot write to a temporary file on local disk either in case there is a failure writing to disk
   // Without keeping the entire batch in memory, there would be no way to recover the records that failed to write
 
-  public BigQueryEventConsumer(DeltaTargetContext context, Storage storage, BigQuery bigQuery, Bucket bucket,
-                               String project, int batchMaxRows, int batchMaxSecondsElapsed) {
+  BigQueryEventConsumer(DeltaTargetContext context, Storage storage, BigQuery bigQuery, Bucket bucket,
+                        String project, int batchMaxRows, int batchMaxSecondsElapsed) {
     this.context = context;
     this.bigQuery = bigQuery;
     this.batchMaxRows = batchMaxRows;
@@ -187,6 +182,9 @@ public class BigQueryEventConsumer implements EventConsumer {
     this.executorService = Executors.newSingleThreadScheduledExecutor();
     this.latestSequenceNum = 0L;
     this.lastFlushTime = 0L;
+    // these maps are only accessed in synchronized methods so they do not need to be thread safe.
+    this.latestMergedSequence = new HashMap<>();
+    this.latestSeenSequence = new HashMap<>();
     this.commitRetryPolicy = new RetryPolicy<>()
       .withMaxAttempts(Integer.MAX_VALUE)
       .withMaxDuration(Duration.of(5, ChronoUnit.MINUTES))
@@ -231,6 +229,7 @@ public class BigQueryEventConsumer implements EventConsumer {
       throw flushException;
     }
 
+    // TODO: sanitize dataset and table names
     DDLEvent event = sequencedEvent.getEvent();
     switch (event.getOperation()) {
       case CREATE_DATABASE:
@@ -268,6 +267,9 @@ public class BigQueryEventConsumer implements EventConsumer {
         }
         break;
       case DROP_TABLE:
+        // need to flush changes before dropping the table, otherwise the next flush will write data that
+        // shouldn't exist
+        flush();
         tableId = TableId.of(project, event.getDatabase(), event.getTable());
         table = bigQuery.getTable(tableId);
         if (table != null) {
@@ -275,6 +277,9 @@ public class BigQueryEventConsumer implements EventConsumer {
         }
         break;
       case ALTER_TABLE:
+        // need to flush any changes before altering the table to ensure all changes before the schema change
+        // are in the table when it is altered.
+        flush();
         tableId = TableId.of(project, event.getDatabase(), event.getTable());
         table = bigQuery.getTable(tableId);
         TableDefinition tableDefinition = StandardTableDefinition.newBuilder()
@@ -286,16 +291,21 @@ public class BigQueryEventConsumer implements EventConsumer {
         } else {
           bigQuery.update(tableInfo);
         }
+        // TODO: alter the staging table as well
         break;
       case RENAME_TABLE:
-        // TODO: create a copy job then delete previous table
+        // TODO: flush changes, execute a copy job, delete previous table, drop old staging table
         break;
       case TRUNCATE_TABLE:
-        // TODO: run a DELETE from table WHERE 1=1 query
+        // TODO: flush changes then run a DELETE from table WHERE 1=1 query
         break;
     }
     latestOffset = event.getOffset();
     latestSequenceNum = sequencedEvent.getSequenceNumber();
+    if (event.getTable() != null) {
+      latestSeenSequence.put(TableId.of(project, event.getDatabase(), event.getTable()),
+                             sequencedEvent.getSequenceNumber());
+    }
     if (event.isSnapshot()) {
       context.setTableSnapshotting(event.getDatabase(), event.getTable());
     } else {
@@ -331,6 +341,14 @@ public class BigQueryEventConsumer implements EventConsumer {
 
     DMLEvent event = sequencedEvent.getEvent();
     gcsWriter.write(sequencedEvent);
+
+    TableId tableId = TableId.of(project, event.getDatabase(), event.getTable());
+    latestSeenSequence.put(tableId, sequencedEvent.getSequenceNumber());
+
+    if (!latestMergedSequence.containsKey(tableId)) {
+      latestMergedSequence.put(tableId, getLatestSequenceNum(tableId));
+    }
+
     latestOffset = event.getOffset();
     latestSequenceNum = sequencedEvent.getSequenceNumber();
     currentBatchSize++;
@@ -372,6 +390,8 @@ public class BigQueryEventConsumer implements EventConsumer {
     }
 
     currentBatchSize = 0;
+    latestMergedSequence.clear();
+    latestMergedSequence.putAll(latestSeenSequence);
     commitOffset();
   }
 
@@ -402,16 +422,17 @@ public class BigQueryEventConsumer implements EventConsumer {
   }
 
   private void loadStagingTable(TableId stagingTableId, TableBlob blob, int attemptNumber) throws InterruptedException {
+    LOG.debug("Loading batch {} into staging table for {}.{}", blob.getBatchId(), blob.getDataset(), blob.getTable());
     Table stagingTable = bigQuery.getTable(stagingTableId);
     if (stagingTable == null) {
       TableDefinition tableDefinition = StandardTableDefinition.newBuilder()
         .setLocation(bucket.getLocation())
         .setSchema(Schemas.convert(blob.getStagingSchema()))
         .build();
-      TableInfo tableInfo = TableInfo.newBuilder(stagingTableId, tableDefinition).build();
+      TableInfo tableInfo = TableInfo.newBuilder(stagingTableId, tableDefinition)
+        .build();
       bigQuery.create(tableInfo);
     }
-    // TODO: verify schema of staging table
 
     // load data from GCS object into staging BQ table
     // batch id is a timestamp generated at the time the first event was seen, so the job id is
@@ -431,20 +452,23 @@ public class BigQueryEventConsumer implements EventConsumer {
       .build();
     Job loadJob = bigQuery.create(jobInfo);
     loadJob.waitFor();
+    LOG.debug("Loaded batch {} into staging table for {}.{}", blob.getBatchId(), blob.getDataset(), blob.getTable());
   }
 
   private void mergeStagingTable(TableId stagingTableId, TableBlob blob,
                                  int attemptNumber) throws InterruptedException {
-    // merge data from staging BQ table into target table
+    LOG.debug("Merging batch {} for {}.{}", blob.getBatchId(), blob.getDataset(), blob.getTable());
     TableId targetTableId = TableId.of(project, blob.getDataset(), blob.getTable());
     Table targetTable = bigQuery.getTable(targetTableId);
     if (targetTable == null) {
-      TableDefinition tableDefinition = StandardTableDefinition.newBuilder()
-        .setLocation(bucket.getLocation())
-        .setSchema(Schemas.convert(blob.getTargetSchema()))
-        .build();
-      TableInfo tableInfo = TableInfo.newBuilder(targetTableId, tableDefinition).build();
-      targetTable = bigQuery.create(tableInfo);
+      // We require that the table already exists and that it was created by this plugin when
+      // handling a DDL create table event.
+      // this is because the primary key for the table is contained in the DDL event, but not in DML events.
+      // so the primary key info is stored in the table definition.
+      // If we had the primary key information here, we could create the table now if it didn't exist for some reason
+      throw new IllegalStateException(
+        String.format("No target table %s.%s found. Please ensure that tables created by the replicator are not "
+                        + "deleted by other processes.", blob.getDataset(), blob.getTable()));
     }
 
     // TODO: figure app should provide a way to get table info given an offset
@@ -452,56 +476,116 @@ public class BigQueryEventConsumer implements EventConsumer {
     pkStr = pkStr == null || !pkStr.startsWith("Primary Key: ") ?
       "_sequence_num" : pkStr.substring("Primary Key: ".length());
     List<String> primaryKey = Arrays.stream(pkStr.split(",")).collect(Collectors.toList());
-    // TODO: verify schema of target table
-    /*
-     * SELECT S.* FROM
-     *   (SELECT * FROM [dataset].[staging table] WHERE _batchId = [batch id]) as S
-     *   JOIN (
-     *     SELECT [primary key], MAX(_sequence_num) as maxSequenceNum
-     *     FROM [dataset].[staging table]
-     *     WHERE _batchId = [batch id]
-     *     GROUP BY [primary key]) as M
-     *   ON [primary key equality] AND S._sequence_num = M.maxSequenceNum
-     */
-    String diffQuery = String.format(
-      "SELECT S.* FROM "
-        + "(SELECT * FROM %s.%s WHERE _batch_id = %d) as S "
-        + "JOIN ("
-        + " SELECT %s, MAX(_sequence_num) as maxSequenceNum "
-        + " FROM %s.%s "
-        + " WHERE _batch_id = %d "
-        + " GROUP BY %s) as M "
-        + "ON %s AND S._sequence_num = M.maxSequenceNum",
-      stagingTableId.getDataset(), stagingTableId.getTable(), blob.getBatchId(),
-      pkStr,
-      stagingTableId.getDataset(), stagingTableId.getTable(),
-      blob.getBatchId(),
-      pkStr,
-      primaryKey.stream().map(k -> String.format("S.%s = M.%s", k, k)).collect(Collectors.joining(" AND ")));
 
-    // D.column1 = T.column1 AND D.column2 = T.column2 ...
-    String equalityStr = primaryKey.stream()
-      .map(name -> String.format("D.%s = T.%s", name, name))
-      .collect(Collectors.joining(" AND "));
-    // column1 = S.column1, column2 = S.column2, ...
-    String updateStr = blob.getTargetSchema().getFields().stream()
-      .map(Schema.Field::getName)
-      .map(name -> String.format("%s = D.%s", name, name))
-      .collect(Collectors.joining(", "));
-    String columns = blob.getTargetSchema().getFields().stream()
-      .map(Schema.Field::getName)
-      .collect(Collectors.joining(", "));
-    String query = String.format(
-      "MERGE %s.%s as T "
-        + "USING (%s) as D ON %s AND D._sequence_num > T._sequence_num "
-        + "WHEN MATCHED AND D._op = \"%s\" THEN DELETE "
-        + "WHEN MATCHED AND D._op IN (\"%s\", \"%s\") THEN UPDATE SET %s "
-        + "WHEN NOT MATCHED AND D._op IN (\"%s\", \"%s\") THEN INSERT (%s) VALUES (%s)",
-      targetTableId.getDataset(), targetTableId.getTable(),
-      diffQuery, equalityStr,
-      DMLOperation.DELETE.name(),
-      DMLOperation.INSERT.name(), DMLOperation.UPDATE.name(), updateStr,
-      DMLOperation.INSERT.name(), DMLOperation.UPDATE.name(), columns, columns);
+    /*
+     * Merge data from staging BQ table into target table.
+     *
+     * If the source table has two columns -- id and name -- the staging table will look something like:
+     *
+     * | _batch_id      | _sequence_num | _op    | _before_id | _before_name | id | name
+     * | 1234567890     | 2             | INSERT |            |              | 0  | alice
+     * | 1234567890     | 3             | UPDATE | 0          | alice        | 1  | alice
+     * | 1234567890     | 4             | UPDATE | 1          | alice        | 2  | alice
+     * | 1234567890     | 5             | DELETE | 2          | alice        | 2  | alice
+     * | 1234567890     | 6             | INSERT |            |              | 0  | Alice
+     * | 1234567890     | 7             | INSERT |            |              | 1  | blob
+     * | 1234567890     | 8             | UPDATE | 1          | blob         | 1  | Bob
+     *
+     * If the primary key is the 'id' field, the merge is performed by running the following query:
+     *
+     * MERGE [target table] as T
+     * USING ($DIFF_QUERY) as D
+     * ON T.id = D._before_id
+     * WHEN MATCHED AND D._op = "DELETE"
+     *   DELETE
+     * WHEN MATCHED AND D._op IN ("INSERT", "UPDATE")
+     *   UPDATE id = D.id, name = D.name
+     * WHEN NOT MATCHED AND D._op IN ("INSERT", "UPDATE")
+     *   INSERT (id, name) VALUES (id, name)
+     *
+     * where the $DIFF_QUERY is:
+     *
+     * SELECT A.* FROM
+     *   (SELECT * FROM [staging table] WHERE _batch_id = 1234567890 AND _sequence_num > $LATEST_APPLIED) as A
+     *   LEFT OUTER JOIN
+     *   (SELECT * FROM [staging table] WHERE _batch_id = 1234567890 AND _sequence_num > $LATEST_APPLIED) as B
+     *   ON A.id = B._before_id AND A._sequence_num < B._sequence_num
+     *   WHERE B._before_id IS NULL
+     *
+     * The purpose of the query is to flatten events within the same batch that have the same primary key.
+     * For example, with the example data given above, the result of the diff query is:
+     *
+     * | _batch_id      | _sequence_num | _op    | _before_id | _before_name | id | name
+     * | 1234567890     | 5             | DELETE |            |              | 2  | alice
+     * | 1234567890     | 6             | INSERT |            |              | 0  | Alice
+     * | 1234567890     | 8             | UPDATE |            |              | 1  | Bob
+     *
+     * The $LATEST_APPLIED part of the query is required for idempotency. If a previous run of the pipeline merged
+     * some results into the target table, but died before it could commit its offset, the merge query could end up
+     * doing the wrong thing because what goes into a batch is not deterministic due to the time bound on batches.
+     */
+
+    /*
+     * SELECT A.* FROM
+     *   (SELECT * FROM [staging table] WHERE _batch_id = 1234567890 AND _sequence_num > $LATEST_APPLIED) as A
+     *   LEFT OUTER JOIN
+     *   (SELECT * FROM [staging table] WHERE _batch_id = 1234567890 AND _sequence_num > $LATEST_APPLIED) as B
+     *   ON A.id = B._before_id AND A._sequence_num < B._sequence_num
+     *   WHERE B._before_id IS NULL
+     */
+    String diffQuery = "SELECT A.* FROM\n" +
+      "(SELECT * FROM " + stagingTableId.getDataset() + "." + stagingTableId.getTable() +
+      " WHERE _batch_id = " + blob.getBatchId() +
+      " AND _sequence_num > " + latestMergedSequence.get(targetTableId) + ") as A\n" +
+      "LEFT OUTER JOIN\n" +
+      "(SELECT * FROM " + stagingTableId.getDataset() + "." + stagingTableId.getTable() +
+      " WHERE _batch_id = " + blob.getBatchId() +
+      " AND _sequence_num > " + latestMergedSequence.get(targetTableId) + ") as B\n" +
+      "ON " +
+      primaryKey.stream()
+        .map(name -> String.format("A.%s = B._before_%s", name, name))
+        .collect(Collectors.joining(" AND ")) +
+      " AND A._sequence_num < B._sequence_num\n" +
+      "WHERE " +
+      primaryKey.stream()
+        .map(name -> String.format("B._before_%s IS NULL", name))
+        .collect(Collectors.joining(" AND "));
+
+    /*
+     * MERGE [target table] as T
+     * USING ($DIFF_QUERY) as D
+     * ON T.id = D._before_id
+     * WHEN MATCHED AND D._op = "DELETE" THEN
+     *   DELETE
+     * WHEN MATCHED AND D._op IN ("INSERT", "UPDATE") THEN
+     *   UPDATE id = D.id, name = D.name
+     * WHEN NOT MATCHED AND D._op IN ("INSERT", "UPDATE") THEN
+     *   INSERT (id, name) VALUES (id, name)
+     */
+    String query = "MERGE " +
+      targetTableId.getDataset() + "." + targetTableId.getTable() + " as T\n" +
+      "USING (" + diffQuery + ") as D\n" +
+      "ON " +
+      primaryKey.stream()
+        .map(name -> String.format("T.%s = D._before_%s", name, name))
+        .collect(Collectors.joining(" AND ")) + "\n" +
+      "WHEN MATCHED AND D._op = \"DELETE\" THEN\n" +
+      "  DELETE\n" +
+      "WHEN MATCHED AND D._op IN (\"INSERT\", \"UPDATE\") THEN\n" +
+      "  UPDATE SET " +
+      blob.getTargetSchema().getFields().stream()
+        .map(Schema.Field::getName)
+        .map(name -> String.format("%s = D.%s", name, name))
+        .collect(Collectors.joining(", ")) + "\n" +
+      "WHEN NOT MATCHED AND D._op IN (\"INSERT\", \"UPDATE\") THEN\n" +
+      "  INSERT (" +
+      blob.getTargetSchema().getFields()
+        .stream().map(Schema.Field::getName)
+        .collect(Collectors.joining(", ")) +
+      ") VALUES (" +
+      blob.getTargetSchema().getFields()
+        .stream().map(Schema.Field::getName)
+        .collect(Collectors.joining(", ")) + ")";
     QueryJobConfiguration mergeJobConf = QueryJobConfiguration.newBuilder(query).build();
     // job id will be different even after a retry because batchid is the timestamp when the first
     // event in the batch was seen
@@ -515,6 +599,7 @@ public class BigQueryEventConsumer implements EventConsumer {
       .build();
     Job mergeJob = bigQuery.create(jobInfo);
     mergeJob.waitFor();
+    LOG.debug("Merged batch {} into {}.{}", blob.getBatchId(), blob.getDataset(), blob.getTable());
   }
 
   private void runWithRetries(ContextualRunnable runnable, TableBlob blob, String onFailedAttemptMessage,
@@ -544,6 +629,56 @@ public class BigQueryEventConsumer implements EventConsumer {
       DeltaFailureException exc = new DeltaFailureException(retriesExhaustedMessage, e);
       flushException = exc;
       throw exc;
+    } catch (FailsafeException e) {
+      if (e.getCause() instanceof InterruptedException) {
+        throw (InterruptedException) e.getCause();
+      }
+      throw e;
+    }
+  }
+
+  private long getLatestSequenceNum(TableId tableId) throws InterruptedException, DeltaFailureException {
+    RetryPolicy<Object> retryPolicy = new RetryPolicy<>()
+      .withMaxDuration(Duration.of(context.getMaxRetrySeconds(), ChronoUnit.SECONDS))
+      // maxDuration must be greater than the delay, otherwise Failsafe complains
+      .withBackoff(Math.min(61, context.getMaxRetrySeconds()) - 1, 120, ChronoUnit.SECONDS)
+      .withMaxAttempts(Integer.MAX_VALUE)
+      .onFailedAttempt(failureContext -> {
+        Throwable t = failureContext.getLastFailure();
+        LOG.error("Failed to read maximum sequence number from {}.{}.", tableId.getDataset(), tableId.getTable(), t);
+      });
+
+    try {
+      return Failsafe.with(retryPolicy).get(() -> {
+        if (bigQuery.getTable(tableId) == null) {
+          return 0L;
+        }
+
+        String query = String.format("SELECT MAX(_sequence_num) FROM %s.%s", tableId.getDataset(), tableId.getTable());
+        QueryJobConfiguration jobConfig = QueryJobConfiguration.of(query);
+        JobId jobId = JobId.of(UUID.randomUUID().toString());
+        Job queryJob = bigQuery.create(JobInfo.newBuilder(jobConfig).setJobId(jobId).build());
+        queryJob.waitFor();
+        TableResult result = queryJob.getQueryResults();
+        Iterator<FieldValueList> resultIter = result.iterateAll().iterator();
+        if (!resultIter.hasNext()) {
+          return 0L;
+        }
+        // query is SELECT MAX(_sequence_num) FROM ...
+        // so there is at most one row and one column in the output.
+        FieldValue val = resultIter.next().get(0);
+        if (val.getValue() == null) {
+          return 0L;
+        }
+
+        long answer = val.getLongValue();
+        LOG.debug("Loaded {} as the latest merged sequence number for {}.{}",
+                  answer, tableId.getDataset(), tableId.getTable());
+        return answer;
+      });
+    } catch (TimeoutExceededException e) {
+      // if the retry timeout was reached, throw a DeltaFailureException to fail the pipeline immediately
+      throw new DeltaFailureException(e.getMessage(), e);
     } catch (FailsafeException e) {
       if (e.getCause() instanceof InterruptedException) {
         throw (InterruptedException) e.getCause();

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright © 2020 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<configuration>
+
+  <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="Console"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
Fixed the algorithm to properly handle updates to primary key
fields. This requires expanding the staging table so that it
includes the previous value of the row as well as the new value.