### PR TITLE
Feature/cdap 16300 improve the primary key handling for big query target

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -709,6 +709,11 @@ public class BigQueryEventConsumer implements EventConsumer {
   }
 
   public static String normalize(String name) {
+    if (name == null) {
+      // avoid potential NPE
+      return null;
+    }
+
     // replace invalid chars with underscores if there are any
     if (!name.matches(VALID_NAME_REGEX)) {
       name = name.replaceAll(INVALID_NAME_REGEX, "_");

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -487,12 +487,12 @@ public class BigQueryEventConsumer implements EventConsumer {
     TableId targetTableId = TableId.of(project, blob.getDataset(), blob.getTable());
     List<String> primaryKey = primaryKeyStore.get(targetTableId);
     if (primaryKey == null) {
-      byte[] stateBytes = context.getState(String.format("bigquery-%s-%s", targetTableId.getDataset(),
-                                                      targetTableId.getTable()));
+      byte[] stateBytes = context.getState(
+        String.format("bigquery-%s-%s", targetTableId.getDataset(), targetTableId.getTable()));
       if (stateBytes == null) {
         throw new DeltaFailureException(
           String.format("Primary key information for table '%s' in dataset '%s' could not be found. This can only " +
-                          "happen if state was manually deleted. Please create a new replicator and start again.",
+                          "happen if state was corrupted. Please create a new replicator and start again.",
                         targetTableId.getTable(), targetTableId.getDataset()));
       }
       BigQueryTableState targetTableState = GSON.fromJson(new String(stateBytes), BigQueryTableState.class);

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryTableState.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryTableState.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.bigquery;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Stores Big Query table state during the replication process.
+ */
+public class BigQueryTableState {
+
+  private final List<String> primaryKeys;
+
+  public BigQueryTableState(List<String> primaryKeys) {
+    this.primaryKeys = Collections.unmodifiableList(new ArrayList<>(primaryKeys));
+  }
+
+  public List<String> getPrimaryKeys() {
+    return primaryKeys;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BigQueryTableState that = (BigQueryTableState) o;
+    return Objects.equals(primaryKeys, that.primaryKeys);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(primaryKeys);
+  }
+}


### PR DESCRIPTION
Firstly, we will use in-memory store to keep the primarykey to table entries. Also, We will use the putState and getState methods exposed in the DeltaContext to store the table primary key information into disk.

Tested on local, no matter first time start or restart, in-memory primary key store and disk state file works as expected.