### PR TITLE
Add CMEK support for bigquery delta target.

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -19,6 +19,7 @@ package io.cdap.delta.bigquery;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.EncryptionConfiguration;
 import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.FormatOptions;
@@ -71,6 +72,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Consumes change events and applies them to BigQuery.
@@ -162,6 +164,7 @@ public class BigQueryEventConsumer implements EventConsumer {
   private final MultiGCSWriter gcsWriter;
   private final Bucket bucket;
   private final String project;
+  private final String cmekKey;
   private final RetryPolicy<Object> commitRetryPolicy;
   private final Map<TableId, Long> latestSeenSequence;
   private final Map<TableId, Long> latestMergedSequence;
@@ -178,7 +181,8 @@ public class BigQueryEventConsumer implements EventConsumer {
   // Without keeping the entire batch in memory, there would be no way to recover the records that failed to write
 
   BigQueryEventConsumer(DeltaTargetContext context, Storage storage, BigQuery bigQuery, Bucket bucket,
-                        String project, int batchMaxRows, int batchMaxSecondsElapsed, String stagingTablePrefix) {
+                        String project, int batchMaxRows, int batchMaxSecondsElapsed, String stagingTablePrefix,
+                        @Nullable String cmekKey) {
     this.context = context;
     this.bigQuery = bigQuery;
     this.batchMaxRows = batchMaxRows;
@@ -189,6 +193,7 @@ public class BigQueryEventConsumer implements EventConsumer {
                                         context);
     this.bucket = bucket;
     this.project = project;
+    this.cmekKey = cmekKey;
     this.currentBatchSize = 0;
     this.executorService = Executors.newSingleThreadScheduledExecutor();
     this.latestSequenceNum = 0L;
@@ -276,7 +281,13 @@ public class BigQueryEventConsumer implements EventConsumer {
           primaryKeyStore.put(tableId, primaryKeys);
           context.putState(String.format("bigquery-%s-%s", tableId.getDataset(), tableId.getTable()),
                            Bytes.toBytes(GSON.toJson(new BigQueryTableState(primaryKeys))));
-          TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
+
+          TableInfo.Builder builder = TableInfo.newBuilder(tableId, tableDefinition);
+          if (cmekKey != null) {
+            builder.setEncryptionConfiguration(
+              EncryptionConfiguration.newBuilder().setKmsKeyName(cmekKey).build());
+          }
+          TableInfo tableInfo = builder.build();
           bigQuery.create(tableInfo);
         }
         break;
@@ -300,7 +311,12 @@ public class BigQueryEventConsumer implements EventConsumer {
         TableDefinition tableDefinition = StandardTableDefinition.newBuilder()
           .setSchema(Schemas.convert(addSequenceNumber(event.getSchema())))
           .build();
-        TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
+        TableInfo.Builder builder = TableInfo.newBuilder(tableId, tableDefinition);
+        if (cmekKey != null) {
+          builder.setEncryptionConfiguration(
+            EncryptionConfiguration.newBuilder().setKmsKeyName(cmekKey).build());
+        }
+        TableInfo tableInfo = builder.build();
         if (table == null) {
           bigQuery.create(tableInfo);
         } else {
@@ -455,8 +471,12 @@ public class BigQueryEventConsumer implements EventConsumer {
         .setLocation(bucket.getLocation())
         .setSchema(Schemas.convert(blob.getStagingSchema()))
         .build();
-      TableInfo tableInfo = TableInfo.newBuilder(stagingTableId, tableDefinition)
-        .build();
+      TableInfo.Builder builder = TableInfo.newBuilder(stagingTableId, tableDefinition);
+      if (cmekKey != null) {
+        builder.setEncryptionConfiguration(
+          EncryptionConfiguration.newBuilder().setKmsKeyName(cmekKey).build());
+      }
+      TableInfo tableInfo = builder.build();
       bigQuery.create(tableInfo);
     }
 
@@ -470,9 +490,13 @@ public class BigQueryEventConsumer implements EventConsumer {
       .build();
     BlobId blobId = blob.getBlob().getBlobId();
     String uri = String.format("gs://%s/%s", blobId.getBucket(), blobId.getName());
-    LoadJobConfiguration loadJobConf = LoadJobConfiguration.newBuilder(stagingTableId, uri)
-      .setFormatOptions(FormatOptions.avro())
-      .build();
+    LoadJobConfiguration.Builder jobConfigBuilder = LoadJobConfiguration.newBuilder(stagingTableId, uri)
+      .setFormatOptions(FormatOptions.avro());
+    if (cmekKey != null) {
+      jobConfigBuilder.setDestinationEncryptionConfiguration(
+        EncryptionConfiguration.newBuilder().setKmsKeyName(cmekKey).build());
+    }
+    LoadJobConfiguration loadJobConf = jobConfigBuilder.build();
     JobInfo jobInfo = JobInfo.newBuilder(loadJobConf)
       .setJobId(jobId)
       .build();
@@ -607,7 +631,12 @@ public class BigQueryEventConsumer implements EventConsumer {
       blob.getTargetSchema().getFields()
         .stream().map(Schema.Field::getName)
         .collect(Collectors.joining(", ")) + ")";
-    QueryJobConfiguration mergeJobConf = QueryJobConfiguration.newBuilder(query).build();
+    QueryJobConfiguration.Builder jobConfigBuilder = QueryJobConfiguration.newBuilder(query);
+    if (cmekKey != null) {
+      jobConfigBuilder.setDestinationEncryptionConfiguration(
+        EncryptionConfiguration.newBuilder().setKmsKeyName(cmekKey).build());
+    }
+    QueryJobConfiguration mergeJobConf = jobConfigBuilder.build();
     // job id will be different even after a retry because batchid is the timestamp when the first
     // event in the batch was seen
     JobId jobId = JobId.newBuilder()
@@ -676,7 +705,12 @@ public class BigQueryEventConsumer implements EventConsumer {
         }
 
         String query = String.format("SELECT MAX(_sequence_num) FROM %s.%s", tableId.getDataset(), tableId.getTable());
-        QueryJobConfiguration jobConfig = QueryJobConfiguration.of(query);
+        QueryJobConfiguration.Builder jobConfigBuilder = QueryJobConfiguration.newBuilder(query);
+        if (cmekKey != null) {
+          jobConfigBuilder.setDestinationEncryptionConfiguration(
+            EncryptionConfiguration.newBuilder().setKmsKeyName(cmekKey).build());
+        }
+        QueryJobConfiguration jobConfig = jobConfigBuilder.build();
         JobId jobId = JobId.of(UUID.randomUUID().toString());
         Job queryJob = bigQuery.create(JobInfo.newBuilder(jobConfig).setJobId(jobId).build());
         queryJob.waitFor();

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
@@ -21,6 +21,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.EncryptionConfiguration;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
@@ -70,6 +71,8 @@ public class BigQueryTarget implements DeltaTarget {
     Credentials credentials = conf.getCredentials();
     String project = conf.getProject();
     String cmekKey = context.getRuntimeArguments().get("gcp.cmek.key.name");
+    EncryptionConfiguration encryptionConfig = cmekKey == null ? null :
+      EncryptionConfiguration.newBuilder().setKmsKeyName(cmekKey).build();
 
     BigQuery bigQuery = BigQueryOptions.newBuilder()
       .setCredentials(credentials)
@@ -101,7 +104,7 @@ public class BigQueryTarget implements DeltaTarget {
     }
 
     return new BigQueryEventConsumer(context, storage, bigQuery, bucket, project, conf.getMaxBatchChanges(),
-                                     conf.getMaxBatchSeconds(), conf.getStagingTablePrefix(), cmekKey);
+                                     conf.getMaxBatchSeconds(), conf.getStagingTablePrefix(), encryptionConfig);
   }
 
   @Override

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
@@ -119,7 +119,7 @@ public class BigQueryEventConsumerTest {
     Bucket bucket = storage.create(BucketInfo.of(bucketName));
 
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(NoOpContext.INSTANCE, storage, bigQuery,
-                                                                    bucket, project, 100, 0, "_staging_");
+                                                                    bucket, project, 100, 0, "_staging_", null);
 
     String dataset = "testInsertUpdateDelete";
     try {

--- a/src/test/java/io/cdap/delta/bigquery/NoOpContext.java
+++ b/src/test/java/io/cdap/delta/bigquery/NoOpContext.java
@@ -26,6 +26,8 @@ import io.cdap.delta.api.DeltaTargetContext;
 import io.cdap.delta.api.Offset;
 import io.cdap.delta.api.ReplicationError;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -82,6 +84,11 @@ public class NoOpContext implements DeltaTargetContext {
   @Override
   public Metrics getMetrics() {
     return null;
+  }
+
+  @Override
+  public Map<String, String> getRuntimeArguments() {
+    return new HashMap<>();
   }
 
   @Override


### PR DESCRIPTION
Add CMEK support for bigquery delta target.
1. CMEK support when creating staging gcs bucket
2. CMEK support when creating tables in bigquery
3. CMEK support when executing jobs in bigquery. 

Testing:
Tested on gcp project and local, bigquery works as expected. 