### PR TITLE
Clean staging table after merging is done.

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -516,6 +516,9 @@ public class BigQueryEventConsumer implements EventConsumer {
       LOG.warn("Failed to delete temporary GCS object {} in bucket {}. The object will need to be manually deleted.",
                blob.getBlob().getBlobId().getName(), blob.getBlob().getBlobId().getBucket(), e);
     }
+    // clean up staging table after merging is done, there is no retry for this clean up since it will not affect
+    // future functionality
+    bigQuery.delete(stagingTableId);
   }
 
   private void loadStagingTable(TableId stagingTableId, TableBlob blob, int attemptNumber) throws InterruptedException {

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -516,9 +516,6 @@ public class BigQueryEventConsumer implements EventConsumer {
       LOG.warn("Failed to delete temporary GCS object {} in bucket {}. The object will need to be manually deleted.",
                blob.getBlob().getBlobId().getName(), blob.getBlob().getBlobId().getBucket(), e);
     }
-    // clean up staging table after merging is done, there is no retry for this clean up since it will not affect
-    // future functionality
-    bigQuery.delete(stagingTableId);
   }
 
   private void loadStagingTable(TableId stagingTableId, TableBlob blob, int attemptNumber) throws InterruptedException {


### PR DESCRIPTION
This PR is used to clean up staging table once the merging is done. By doing this, there will be no staging table exists under the big query dataset once the merging is done. 

Tested on big query side, events was able to propagate and apply as expected.