### PR TITLE
CDAP-16558 removed max batch size

### DIFF
--- a/docs/bigquery-cdcTarget.md
+++ b/docs/bigquery-cdcTarget.md
@@ -11,6 +11,18 @@ The final target tables will include all the original columns from the source ta
 _sequence_num column. The sequence number is used to ensure that data is not duplicated or missed in
 replicator failure scenarios.
 
+Quotas
+------
+BigQuery has a quota of 1,000 operations per table per day, and 100,000 operations per project per day.
+Every load interval, for each target table, this plugin will perform one operation.
+With the default value of 90 seconds, this results in 960 merge jobs for each target table.
+This means if there are no other processes loading data into BigQuery for your project,
+you are limited to replicating 104 tables per day.
+If you would like to replicate more tables, or you have additional processes loading data, you will
+need to increase the load interval accordingly.
+
+See https://cloud.google.com/bigquery/quotas for more information about BigQuery quotas.
+
 Credentials
 -----------
 If the plugin is run on a Google Cloud Dataproc cluster, the service account key does not need to be
@@ -22,6 +34,12 @@ The service account key can be found on the Dashboard in the Cloud Platform Cons
 Make sure the account key has permission to access BigQuery.
 The service account key file needs to be available on every node in your cluster and
 must be readable by all users running the job.
+
+Limitations
+-----------
+Tables must have a primary key in order to be replicated.
+
+Table rename operations are not supported. If a rename event is encountered, it will be ignored.
 
 Properties
 ----------
@@ -37,9 +55,10 @@ BigQuery dataset.
 BigQuery. When running on a Dataproc cluster, this can be left blank, which will use the service account
 of the cluster.
 
-**Max Batch Seconds**: Maximum number of seconds to wait before merging a batch of changes.
-
-**Max Batch Changes**: Maximum number of change events to include in a single batch.
+**Load Interval**: Number of seconds to wait before loading a batch of data into BigQuery. 
+Note that BigQuery has a quota of 1000 load jobs per table, so it is not safe to set this to a value lower
+than 90 seconds, unless you are certain that there are periods of the day where there will be no
+updates made to the table.
 
 **Staging Table Prefix**: Changes are first written to a staging table before merged to the final table.
 Staging tables are named used this prefix prepended to the target table name.

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
@@ -103,13 +103,13 @@ public class BigQueryTarget implements DeltaTarget {
       }
     }
 
-    return new BigQueryEventConsumer(context, storage, bigQuery, bucket, project, conf.getMaxBatchChanges(),
-                                     conf.getMaxBatchSeconds(), conf.getStagingTablePrefix(), encryptionConfig);
+    return new BigQueryEventConsumer(context, storage, bigQuery, bucket, project,
+                                     conf.getLoadIntervalSeconds(), conf.getStagingTablePrefix(), encryptionConfig);
   }
 
   @Override
   public TableAssessor<StandardizedTableDetail> createTableAssessor(Configurer configurer) {
-    return new BigQueryAssessor(conf.getStagingTablePrefix());
+    return new BigQueryAssessor(conf.stagingTablePrefix, conf.loadInterval);
   }
 
   /**
@@ -142,23 +142,15 @@ public class BigQueryTarget implements DeltaTarget {
     private String stagingTablePrefix;
 
     @Nullable
-    @Description("Maximum number of seconds to wait before writing a batch of changes.")
-    private Integer maxBatchSeconds;
-
-    @Nullable
-    @Description("Maximum number of changes to include in a batch.")
-    private Integer maxBatchChanges;
+    @Description("Number of seconds to wait in between loading batches of changes into BigQuery.")
+    private Integer loadInterval;
 
     private String getStagingTablePrefix() {
       return stagingTablePrefix == null || stagingTablePrefix.isEmpty() ? "_staging_" : stagingTablePrefix;
     }
 
-    int getMaxBatchSeconds() {
-      return maxBatchSeconds == null ? 60 : maxBatchSeconds;
-    }
-
-    int getMaxBatchChanges() {
-      return maxBatchChanges == null ? 1000 * 1000 : maxBatchChanges;
+    int getLoadIntervalSeconds() {
+      return loadInterval == null ? 90 : loadInterval;
     }
 
     private String getProject() {

--- a/src/main/java/io/cdap/delta/bigquery/TableBlob.java
+++ b/src/main/java/io/cdap/delta/bigquery/TableBlob.java
@@ -28,15 +28,18 @@ public class TableBlob {
   private final Schema stagingSchema;
   private final Schema targetSchema;
   private final long batchId;
+  private final long numEvents;
   private final Blob blob;
 
-  public TableBlob(String dataset, String table, Schema targetSchema, Schema stagingSchema, long batchId, Blob blob) {
+  public TableBlob(String dataset, String table, Schema targetSchema, Schema stagingSchema, long batchId,
+                   long numEvents, Blob blob) {
     this.dataset = dataset;
     this.table = table;
     this.targetSchema = targetSchema;
     this.stagingSchema = stagingSchema;
     this.batchId = batchId;
     this.blob = blob;
+    this.numEvents = numEvents;
   }
 
   public String getDataset() {
@@ -57,6 +60,10 @@ public class TableBlob {
 
   public long getBatchId() {
     return batchId;
+  }
+
+  public long getNumEvents() {
+    return numEvents;
   }
 
   public Blob getBlob() {

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
@@ -123,7 +123,7 @@ public class BigQueryEventConsumerTest {
     Bucket bucket = storage.create(BucketInfo.of(bucketName));
 
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(NoOpContext.INSTANCE, storage, bigQuery, bucket,
-                                                                    project, 100, 0, STAGING_TABLE_PREFIX, null);
+                                                                    project, 0, STAGING_TABLE_PREFIX, null);
 
     String dataset = "testInsertUpdateDelete";
     try {
@@ -147,7 +147,7 @@ public class BigQueryEventConsumerTest {
     Bucket bucket = storage.create(BucketInfo.of(bucketName));
 
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(NoOpContext.INSTANCE, storage, bigQuery, bucket,
-                                                                    project, 100, 0, STAGING_TABLE_PREFIX, null);
+                                                                    project, 0, STAGING_TABLE_PREFIX, null);
 
     String dataset = "testInsertTruncate";
     try {

--- a/src/test/java/io/cdap/delta/bigquery/NoOpContext.java
+++ b/src/test/java/io/cdap/delta/bigquery/NoOpContext.java
@@ -98,7 +98,7 @@ public class NoOpContext implements DeltaTargetContext {
 
   @Override
   public int getMaxRetrySeconds() {
-    return 60;
+    return 0;
   }
 
   @Nullable

--- a/widgets/bigquery-cdcTarget.json
+++ b/widgets/bigquery-cdcTarget.json
@@ -36,19 +36,11 @@
       "label" : "Advanced",
       "properties" : [
         {
-          "name": "maxBatchSeconds",
-          "label": "Max Batch Seconds",
+          "name": "loadInterval",
+          "label": "Load Interval (seconds)",
           "widget-type": "textbox",
           "widget-attributes": {
-            "default": "30"
-          }
-        },
-        {
-          "name": "maxBatchChanges",
-          "label": "Max Batch Changes",
-          "widget-type": "textbox",
-          "widget-attributes": {
-            "default": "10000"
+            "default": "90"
           }
         },
         {


### PR DESCRIPTION
Since there is a 1000 load job per table per day limit, changed
the plugin to remove the max batch size property. This is no longer
needed anyway, since the plugin streams all its data directly
to GCS and doesn't keep much information in memory.

Added more detailed documentation, and added a feature problem
to the assessment if the load interval is likely too short.