### PR TITLE
CDAP-16575 always record the table primary key

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -274,12 +274,12 @@ public class BigQueryEventConsumer implements EventConsumer {
       case CREATE_TABLE:
         TableId tableId = TableId.of(project, normalizedDatabaseName, normalizedTableName);
         Table table = bigQuery.getTable(tableId);
+        updatePrimaryKey(tableId, event.getPrimaryKey());
         // TODO: check schema of table if it exists already
         if (table == null) {
           TableDefinition tableDefinition = StandardTableDefinition.newBuilder()
             .setSchema(Schemas.convert(addSequenceNumber(event.getSchema())))
             .build();
-          updatePrimaryKey(tableId, event.getPrimaryKey());
 
           TableInfo.Builder builder = TableInfo.newBuilder(tableId, tableDefinition);
           if (encryptionConfig != null) {


### PR DESCRIPTION
Fixed the event consumer to always record the table primary key
even if the big query table already exists. This is because the
replicator may be configured to ignore drop table events, in which
case the table may exist, but the replicator still needs to record
primary key information.