### PR TITLE
CDAP-16737 retry ddl failures

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
@@ -105,7 +105,7 @@ public class BigQueryTarget implements DeltaTarget {
 
     return new BigQueryEventConsumer(context, storage, bigQuery, bucket, project,
                                      conf.getLoadIntervalSeconds(), conf.getStagingTablePrefix(),
-                                     conf.requiresManualDrops(), encryptionConfig);
+                                     conf.requiresManualDrops(), encryptionConfig, null);
   }
 
   @Override

--- a/src/test/java/io/cdap/delta/bigquery/MockContext.java
+++ b/src/test/java/io/cdap/delta/bigquery/MockContext.java
@@ -31,10 +31,15 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * No-op version of the context.
+ * Mock version of the context.
  */
-public class NoOpContext implements DeltaTargetContext {
-  public static final DeltaTargetContext INSTANCE = new NoOpContext();
+public class MockContext implements DeltaTargetContext {
+  public static final DeltaTargetContext INSTANCE = new MockContext(0);
+  private final int maxRetrySeconds;
+
+  public MockContext(int maxRetrySeconds) {
+    this.maxRetrySeconds = maxRetrySeconds;
+  }
 
   @Override
   public void incrementCount(DMLOperation dmlOperation) {
@@ -98,7 +103,7 @@ public class NoOpContext implements DeltaTargetContext {
 
   @Override
   public int getMaxRetrySeconds() {
-    return 0;
+    return maxRetrySeconds;
   }
 
   @Nullable


### PR DESCRIPTION
Retry DDL event failures within the target instead of forcing the
replicator to reset state. This results in more user friendly
logs, where just the BQ error is retried instead of a bunch of
logging around stopping and restarting the event readers.