### PR TITLE
CDAP-17407 Update bigquery target plugin to handle un-ordered events.

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/Constants.java
+++ b/src/main/java/io/cdap/delta/bigquery/Constants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.bigquery;
+
+/**
+ * Class defining constants.
+ */
+public final class Constants {
+  public static final String SEQUENCE_NUM = "_sequence_num";
+  public static final String SOURCE_TIMESTAMP = "_source_timestamp";
+  public static final String IS_DELETED = "_is_deleted";
+  public static final String ROW_ID = "_row_id";
+  public static final String OPERATION = "_op";
+  public static final String BATCH_ID = "_batch_id";
+
+  private Constants() {}
+}

--- a/src/test/java/io/cdap/delta/bigquery/MockContext.java
+++ b/src/test/java/io/cdap/delta/bigquery/MockContext.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.metrics.Metrics;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.delta.api.DDLOperation;
 import io.cdap.delta.api.DMLOperation;
+import io.cdap.delta.api.DeltaPipelineId;
 import io.cdap.delta.api.DeltaTargetContext;
 import io.cdap.delta.api.Offset;
 import io.cdap.delta.api.ReplicationError;
@@ -123,6 +124,11 @@ public class MockContext implements DeltaTargetContext {
   @Override
   public void putState(String s, byte[] bytes) {
     // no-op
+  }
+
+  @Override
+  public DeltaPipelineId getPipelineId() {
+    return new DeltaPipelineId("default", "app", 0L);
   }
 
   @Override


### PR DESCRIPTION
This PR is based on the app changes from https://github.com/data-integrations/delta/pull/81. 

Depending on the ordering of events generated by source, staging table will have different schema. 

If the source used in the pipeline is generating `UN-ORDERED` events, then for source table with fields (id, name), staging table would contain following columns:
```
          _op (string)
          _batch_id (long)
          _sequence_num (long)
          _source_timestamp (long)
          _row_id (string)
          id (long)
          name (string)
```

If the source used in the pipeline is generating `ORDERED` events, then for source table with fields (id, name), staging table would contain following columns (this is unchanged):
```
          _op (string)
          _batch_id (long)
          _sequence_num (long)
          id (long)
          name (string)
          _before_id (long)
          _before_name (string)
```

Target table will have following schema irrespective of the ordering of source:

```
_sequence_num (long) 
_is_deleted (boolean  and null for ORDERED source)
_row_id (string  and null for ORDERED source)
_source_timestamp (long and null for ORDERED source)
id (long)
name (string)
```

Sample merge query generated when the source is ORDERED (this query is same as current implementation):
```
MERGE cdc.targettableordered as T
USING (SELECT A.* FROM
(SELECT * FROM cdc.stagingtblordered WHERE _batch_id = 1111 AND _sequence_num > 10) as A
LEFT OUTER JOIN
(SELECT * FROM cdc.stagingtblordered WHERE _batch_id = 1111 AND _sequence_num > 10) as B
ON A.id = B._before_id AND A.name = B._before_name AND A._sequence_num < B._sequence_num
WHERE B._before_id IS NULL AND B._before_name IS NULL) as D
ON T.id = D._before_id AND T.name = D._before_name
WHEN MATCHED AND D._op = "DELETE" THEN
  DELETE
WHEN MATCHED AND D._op IN ("INSERT", "UPDATE")  THEN
  UPDATE SET _sequence_num = D._sequence_num, id = D.id, name = D.name, id1 = D.id1
WHEN NOT MATCHED AND D._op IN ("INSERT", "UPDATE") THEN
  INSERT (_sequence_num, id, name, id1) VALUES (_sequence_num, id, name, id1)
```

Sample merge query generated when the source is UN_ORDERED:
```
MERGE cdc.targettableordered as T
USING (SELECT A.* FROM
(SELECT * FROM cdc.unorderedstagingtbl WHERE _batch_id = 1111 AND _sequence_num > 10) as A
LEFT OUTER JOIN
(SELECT * FROM cdc.unorderedstagingtbl WHERE _batch_id = 1111 AND _sequence_num > 10) as B
ON A._row_id = B._row_id AND A._source_timestamp < B._source_timestamp 
WHERE  B._row_id IS NULL ) as D
ON  T._row_id = D._row_id 
WHEN MATCHED AND D._op = "DELETE" THEN
  UPDATE SET _is_deleted = true 
WHEN MATCHED AND D._op IN ("INSERT", "UPDATE")  AND D._source_timestamp > T._source_timestamp AND T._is_deleted = false  THEN
  UPDATE SET _sequence_num = D._sequence_num, _source_timestamp = D._source_timestamp, id = D.id, name = D.name, id1 = D.id1
WHEN NOT MATCHED AND D._op IN ("INSERT", "UPDATE") THEN
  INSERT (_sequence_num, _row_id, _source_timestamp, id, name, id1) VALUES (_sequence_num, _row_id, _source_timestamp, id, name, id1)
```



