### PR TITLE
CDAP-17371 Propagate source database schema name to the applications setTableError method.

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -952,7 +952,8 @@ public class BigQueryEventConsumer implements EventConsumer {
         LOG.error(onFailedAttemptMessage, t);
         // its ok to set table state every retry, because this is a no-op if there is no change to the state.
         try {
-          context.setTableError(blob.getDataset(), blob.getTable(), new ReplicationError(t));
+          context.setTableError(blob.getDataset(), blob.getSourceDbSchemaName(), blob.getTable(),
+                                new ReplicationError(t));
         } catch (IOException e) {
           // setting table state is not a fatal error, log a warning and continue on
           LOG.warn("Unable to set error state for table {}.{}. Replication state for the table may be incorrect.",

--- a/src/main/java/io/cdap/delta/bigquery/TableBlob.java
+++ b/src/main/java/io/cdap/delta/bigquery/TableBlob.java
@@ -19,21 +19,25 @@ package io.cdap.delta.bigquery;
 import com.google.cloud.storage.Blob;
 import io.cdap.cdap.api.data.schema.Schema;
 
+import javax.annotation.Nullable;
+
 /**
  * A batch of events for a table, stored as a GCS blob.
  */
 public class TableBlob {
   private final String dataset;
   private final String table;
+  private final String sourceDbSchemaName;
   private final Schema stagingSchema;
   private final Schema targetSchema;
   private final long batchId;
   private final long numEvents;
   private final Blob blob;
 
-  public TableBlob(String dataset, String table, Schema targetSchema, Schema stagingSchema, long batchId,
-                   long numEvents, Blob blob) {
+  public TableBlob(String dataset, @Nullable String sourceDbSchemaName, String table, Schema targetSchema,
+                   Schema stagingSchema, long batchId, long numEvents, Blob blob) {
     this.dataset = dataset;
+    this.sourceDbSchemaName = sourceDbSchemaName;
     this.table = table;
     this.targetSchema = targetSchema;
     this.stagingSchema = stagingSchema;
@@ -52,6 +56,11 @@ public class TableBlob {
 
   public Schema getStagingSchema() {
     return stagingSchema;
+  }
+
+  @Nullable
+  public String getSourceDbSchemaName() {
+    return sourceDbSchemaName;
   }
 
   public Schema getTargetSchema() {

--- a/src/test/java/io/cdap/delta/bigquery/MockContext.java
+++ b/src/test/java/io/cdap/delta/bigquery/MockContext.java
@@ -29,6 +29,7 @@ import io.cdap.delta.api.ReplicationError;
 import io.cdap.delta.api.SourceProperties;
 import io.cdap.delta.api.SourceTable;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,6 +67,12 @@ public class MockContext implements DeltaTargetContext {
   @Override
   public void setTableError(String s, String s1, ReplicationError replicationError) {
     // no-op
+  }
+
+  @Override
+  public void setTableError(String s, @Nullable String s1, String s2,
+                            ReplicationError replicationError) throws IOException {
+
   }
 
   @Override


### PR DESCRIPTION
First commit cherry-picks #71 and second commit cherry-picks #72. Added them in single PR since they are related.
