### PR TITLE
CDAP-17523 Default the text area to 'auto-detect' similar to other properties such as project id.

### DIFF
--- a/widgets/bigquery-cdcTarget.json
+++ b/widgets/bigquery-cdcTarget.json
@@ -23,7 +23,10 @@
         {
           "name": "serviceAccountKey",
           "label": "Service Account Key",
-          "widget-type": "securekey-textarea"
+          "widget-type": "securekey-textarea",
+          "widget-attributes": {
+            "default": "auto-detect"
+          }
         }
       ]
     },


### PR DESCRIPTION
If the service account key is not provided, it is not sent by UI (i.e. `null` on the backend) and is treated as `auto-detect`. 
However its possible that user enters some data accidentally in the field and removes it, at which point UI sends empty string (i.e. "" on the backend which is different from `null` and `auto-detect`) 

Marking it explicitly as `auto-detect` (similar to Project ID field) in the widget JSON to help avoid such scenarios.
