### PR TITLE
PLUGIN-645 Add support for DateTime in replication BQ target.

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/AvroEventWriter.java
+++ b/src/main/java/io/cdap/delta/bigquery/AvroEventWriter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.bigquery;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.io.DatumWriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * EventWriter that writes records in Avro format.
+ */
+public class AvroEventWriter implements EventWriter {
+  private DataFileWriter<StructuredRecord> avroWriter;
+
+  AvroEventWriter(org.apache.avro.Schema avroSchema, OutputStream outputStream) {
+    DatumWriter<StructuredRecord> datumWriter = new RecordDatumWriter();
+    try {
+      avroWriter = new DataFileWriter<>(datumWriter).create(avroSchema, outputStream);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create avro event writer.", e);
+    }
+  }
+
+  @Override
+  public void write(StructuredRecord record) throws IOException {
+    avroWriter.append(record);
+  }
+
+  @Override
+  public void close() throws IOException {
+    avroWriter.close();
+  }
+}

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -745,6 +745,9 @@ public class BigQueryEventConsumer implements EventConsumer {
     if (encryptionConfig != null) {
       jobConfigBuilder.setDestinationEncryptionConfiguration(encryptionConfig);
     }
+    if (blob.isJsonFormat()) {
+      jobConfigBuilder.setFormatOptions(FormatOptions.json());
+    }
     LoadJobConfiguration loadJobConf = jobConfigBuilder.build();
     JobInfo jobInfo = JobInfo.newBuilder(loadJobConf)
       .setJobId(jobId)

--- a/src/main/java/io/cdap/delta/bigquery/EventWriter.java
+++ b/src/main/java/io/cdap/delta/bigquery/EventWriter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.bigquery;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Write event represented as StructuredRecord to the storage.
+ */
+interface EventWriter extends Closeable {
+  void write(StructuredRecord record) throws IOException;
+}

--- a/src/main/java/io/cdap/delta/bigquery/JsonEventWriter.java
+++ b/src/main/java/io/cdap/delta/bigquery/JsonEventWriter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.bigquery;
+
+import com.google.gson.internal.bind.JsonTreeWriter;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Objects;
+
+/**
+ * EventWriter that writes records in JSON format.
+ */
+public class JsonEventWriter implements EventWriter {
+  private final BufferedWriter jsonWriter;
+
+  JsonEventWriter(OutputStream outputStream) {
+    this.jsonWriter = new BufferedWriter(new OutputStreamWriter(outputStream));
+  }
+
+  @Override
+  public void write(StructuredRecord record) throws IOException {
+    try (JsonTreeWriter writer = new JsonTreeWriter()) {
+      writer.beginObject();
+      for (Schema.Field recordField : Objects.requireNonNull(record.getSchema().getFields())) {
+        StructuredRecordToJson.write(writer, recordField.getName(), record.get(recordField.getName()),
+                                     recordField.getSchema());
+      }
+      writer.endObject();
+      jsonWriter.write(writer.get().getAsJsonObject().toString());
+      jsonWriter.newLine();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    jsonWriter.close();
+  }
+}

--- a/src/main/java/io/cdap/delta/bigquery/Schemas.java
+++ b/src/main/java/io/cdap/delta/bigquery/Schemas.java
@@ -120,6 +120,8 @@ public class Schemas {
         return StandardSQLTypeName.DATE;
       case DECIMAL:
         return StandardSQLTypeName.NUMERIC;
+      case DATETIME:
+        return StandardSQLTypeName.DATETIME;
     }
     return null;
   }

--- a/src/main/java/io/cdap/delta/bigquery/StructuredRecordToJson.java
+++ b/src/main/java/io/cdap/delta/bigquery/StructuredRecordToJson.java
@@ -1,0 +1,298 @@
+package io.cdap.delta.bigquery;
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.stream.JsonWriter;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+
+/**
+ * Util class to convert structured record into json.
+ */
+public final class StructuredRecordToJson {
+  private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+  private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS");
+  // array of arrays and map of arrays are not supported by big query
+  private static final Set<Schema.Type> UNSUPPORTED_ARRAY_TYPES = ImmutableSet.of(Schema.Type.ARRAY, Schema.Type.MAP);
+
+  /**
+   * Writes object and writes to json writer.
+   * @param writer json writer to write the object to
+   * @param name name of the field to be written
+   * @param object object to be written
+   * @param fieldSchema field schema to be written
+   */
+  public static void write(JsonWriter writer, String name, Object object, Schema fieldSchema) throws IOException {
+    write(writer, name, false, object, fieldSchema);
+  }
+
+  /**
+   * Writes object and writes to json writer.
+   * @param writer json writer to write the object to
+   * @param name name of the field to be written
+   * @param isArrayItem true if the method is writing array item. This means the name of the array field will not be
+   *                    added to the json writer
+   * @param object object to be written
+   * @param fieldSchema field schema to be written
+   */
+  private static void write(JsonWriter writer, String name, boolean isArrayItem, Object object,
+                            Schema fieldSchema) throws IOException {
+    Schema schema = getNonNullableSchema(fieldSchema);
+    switch (schema.getType()) {
+      case NULL:
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case BOOLEAN:
+      case STRING:
+      case BYTES:
+        writeSimpleTypes(writer, name, isArrayItem, object, schema);
+        break;
+      case ARRAY:
+        writeArray(writer, name, object, schema);
+        break;
+      case RECORD:
+        writeRecord(writer, name, object, schema);
+        break;
+      default:
+        throw new IllegalStateException(
+          String.format("Field '%s' is of unsupported type '%s'", name, fieldSchema.getType()));
+    }
+  }
+
+  /**
+   * Writes simple types to json writer.
+   * @param writer json writer
+   * @param name name of the field to be written
+   * @param isArrayItem true if the method is writing array item. This means the name of the array field will not be
+   *                    added to the json writer
+   * @param object object to be written
+   * @param schema field schema to be written
+   */
+  private static void writeSimpleTypes(JsonWriter writer, String name, boolean isArrayItem, Object object,
+                                       Schema schema) throws IOException {
+    if (!isArrayItem) {
+      writer.name(name);
+    }
+
+    if (object == null) {
+      writer.nullValue();
+      return;
+    }
+
+    Schema.LogicalType logicalType = schema.getLogicalType();
+    if (logicalType != null) {
+      switch (logicalType) {
+        case DATE:
+          writer.value(Objects.requireNonNull(LocalDate.ofEpochDay(((Integer) object).longValue()).toString()));
+          break;
+        case TIME_MILLIS:
+          writer.value(TIME_FORMATTER.format(
+            Objects.requireNonNull(LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(((Integer) object))))));
+          break;
+        case TIME_MICROS:
+          writer.value(TIME_FORMATTER.format(
+            Objects.requireNonNull(LocalTime.ofNanoOfDay(TimeUnit.MICROSECONDS.toNanos((Long) object)))));
+          break;
+        case TIMESTAMP_MILLIS:
+          //timestamp for json input should be in this format yyyy-MM-dd HH:mm:ss.SSSSSS
+          writer.value(DATETIME_FORMATTER.format(
+            Objects.requireNonNull(getZonedDateTime((long) object, TimeUnit.MILLISECONDS))));
+          break;
+        case TIMESTAMP_MICROS:
+          writer.value(DATETIME_FORMATTER.format(
+            Objects.requireNonNull(getZonedDateTime((long) object, TimeUnit.MICROSECONDS))));
+          break;
+        case DECIMAL:
+          writer.value(Objects.requireNonNull(getDecimal(name, (byte[]) object, schema)).toPlainString());
+          break;
+        case DATETIME:
+          //datetime should be already an ISO-8601 string
+          writer.value(Objects.requireNonNull(object.toString()));
+          break;
+        default:
+          throw new IllegalStateException(
+            String.format("Field '%s' is of unsupported type '%s'", name, logicalType.getToken()));
+      }
+      return;
+    }
+
+    switch (schema.getType()) {
+      case NULL:
+        writer.nullValue(); // nothing much to do here.
+        break;
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+        writer.value((Number) object);
+        break;
+      case BOOLEAN:
+        writer.value((Boolean) object);
+        break;
+      case STRING:
+        writer.value(object.toString());
+        break;
+      case BYTES:
+        if (object instanceof byte[]) {
+          writer.value(Base64.getEncoder().encodeToString((byte[]) object));
+        } else if (object instanceof ByteBuffer) {
+          writer.value(Base64.getEncoder().encodeToString(Bytes.toBytes((ByteBuffer) object)));
+        } else {
+          throw new IllegalStateException(String.format("Expected value of Field '%s' to be bytes but got '%s'",
+                                                        name, object.getClass().getSimpleName()));
+        }
+        break;
+      default:
+        throw new IllegalStateException(String.format("Field '%s' is of unsupported type '%s'",
+                                                      name, schema.getType()));
+    }
+  }
+
+  private static void writeArray(JsonWriter writer,
+                                 String name,
+                                 @Nullable Object value,
+                                 Schema fieldSchema) throws IOException {
+    if (value == null) {
+      throw new RuntimeException(
+        String.format("Field '%s' is of value null, which is not a valid value for BigQuery type array.", name));
+    }
+
+    Collection collection;
+    if (value instanceof Collection) {
+      collection = (Collection) value;
+    } else if (value instanceof Object[]) {
+      collection = Arrays.asList((Object[]) value);
+    } else {
+      throw new IllegalArgumentException(String.format(
+        "A value for the field '%s' is of type '%s' when it is expected to be a Collection or array.",
+        name, value.getClass().getSimpleName()));
+    }
+
+    Schema componentSchema = getNonNullableSchema(Objects.requireNonNull(fieldSchema.getComponentSchema()));
+    if (UNSUPPORTED_ARRAY_TYPES.contains(componentSchema.getType())) {
+      throw new IllegalArgumentException(String.format("Field '%s' is an array of '%s', " +
+                                                         "which is not a valid BigQuery type.",
+                                                       name, componentSchema));
+    }
+
+    writer.name(name);
+    writer.beginArray();
+
+    for (Object element : collection) {
+      // BigQuery does not allow null values in array items
+      if (element == null) {
+        throw new IllegalArgumentException(String.format("Field '%s' contains null values in its array, " +
+                                                           "which is not allowed by BigQuery.", name));
+      }
+      if (element instanceof StructuredRecord) {
+        StructuredRecord record = (StructuredRecord) element;
+        processRecord(writer, record, Objects.requireNonNull(record.getSchema().getFields()));
+      } else {
+        write(writer, name, true, element, componentSchema);
+      }
+    }
+    writer.endArray();
+  }
+
+  private static void writeRecord(JsonWriter writer,
+                                  String name,
+                                  @Nullable Object value,
+                                  Schema fieldSchema) throws IOException {
+    if (value == null) {
+      writer.name(name);
+      writer.nullValue();
+      return;
+    }
+
+    if (!(value instanceof StructuredRecord)) {
+      throw new IllegalStateException(
+        String.format("Value is of type '%s', expected type is '%s'",
+                      value.getClass().getSimpleName(), StructuredRecord.class.getSimpleName()));
+    }
+
+    writer.name(name);
+    processRecord(writer, (StructuredRecord) value, Objects.requireNonNull(fieldSchema.getFields()));
+  }
+
+  private static void processRecord(JsonWriter writer,
+                                    StructuredRecord record,
+                                    List<Schema.Field> fields) throws IOException {
+    writer.beginObject();
+    for (Schema.Field field : fields) {
+      write(writer, field.getName(), record.get(field.getName()), field.getSchema());
+    }
+    writer.endObject();
+  }
+
+  private static ZonedDateTime getZonedDateTime(long ts, TimeUnit unit) {
+    long mod = unit.convert(1, TimeUnit.SECONDS);
+    int fraction = (int) (ts % mod);
+    long tsInSeconds = unit.toSeconds(ts);
+    // create an Instant with time in seconds and fraction which will be stored as nano seconds.
+    Instant instant = Instant.ofEpochSecond(tsInSeconds, unit.toNanos(fraction));
+    return ZonedDateTime.ofInstant(instant, ZoneId.ofOffset("UTC", ZoneOffset.UTC));
+  }
+
+  private static BigDecimal getDecimal(String name, byte[] value, Schema schema) {
+    int scale = schema.getScale();
+    BigDecimal decimal = new BigDecimal(new BigInteger(value), scale);
+    if (decimal.precision() > 38 || decimal.scale() > 9) {
+      throw new IllegalArgumentException(
+        String.format("Numeric Field '%s' has invalid precision '%s' and scale '%s'. " +
+                        "Precision must be at most 38 and scale must be at most 9.",
+                      name, decimal.precision(), decimal.scale()));
+    }
+    return decimal;
+  }
+
+  /**
+   * Gets non nullable type from provided schema.
+   *
+   * @param schema schema to be used
+   * @return non-nullable {@link Schema}
+   */
+  private static Schema getNonNullableSchema(Schema schema) {
+    return schema.isNullable() ? schema.getNonNullable() : schema;
+  }
+
+  private StructuredRecordToJson() {
+    //no-op
+  }
+}

--- a/src/main/java/io/cdap/delta/bigquery/TableBlob.java
+++ b/src/main/java/io/cdap/delta/bigquery/TableBlob.java
@@ -34,9 +34,11 @@ public class TableBlob {
   private final long numEvents;
   private final Blob blob;
   private final boolean snapshotOnly;
+  private final boolean jsonFormat;
 
   public TableBlob(String dataset, @Nullable String sourceDbSchemaName, String table, Schema targetSchema,
-                   Schema stagingSchema, long batchId, long numEvents, Blob blob, boolean snapshotOnly) {
+                   Schema stagingSchema, long batchId, long numEvents, Blob blob, boolean snapshotOnly,
+                   boolean jsonFormat) {
     this.dataset = dataset;
     this.sourceDbSchemaName = sourceDbSchemaName;
     this.table = table;
@@ -46,6 +48,7 @@ public class TableBlob {
     this.blob = blob;
     this.numEvents = numEvents;
     this.snapshotOnly = snapshotOnly;
+    this.jsonFormat = jsonFormat;
   }
 
   public String getDataset() {
@@ -83,5 +86,9 @@ public class TableBlob {
 
   public boolean isSnapshotOnly() {
     return snapshotOnly;
+  }
+
+  public boolean isJsonFormat() {
+    return jsonFormat;
   }
 }


### PR DESCRIPTION
https://cdap.atlassian.net/browse/PLUGIN-645
This PR has following changes:
1. `EventWriter` interface and it's implementations `AvroEventWriter` and `JsonEventWriter`. `JsonEventWriter` is used when table is determined to have `DateTime` field in it, else `AvroEventWriter` is used to write StructuredRecord to GCS bucket.
2. Copy of class https://github.com/data-integrations/google-cloud/blob/develop/src/main/java/io/cdap/plugin/gcp/bigquery/sink/BigQueryRecordToJson.java and renamed to `StructuredRecordToJson`.  
