### PR TITLE
CDAP-17586 don't deal with sequence number of DDL event

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -286,29 +286,9 @@ public class BigQueryEventConsumer implements EventConsumer {
                    String.format("Exhausted retries trying to apply '%s' DDL event", event.getOperation())
                    );
 
-    long sequenceNumber = sequencedEvent.getSequenceNumber();
-    if (normalizedTableName != null) {
-      TableId tableId = TableId.of(project, normalizedDatabaseName, normalizedTableName);
-      Long latestMergedSequencedNum = latestMergedSequence.get(tableId);
-      if (latestMergedSequencedNum == null) {
-        // first event of the table
-        latestMergedSequencedNum  = getLatestSequenceNum(tableId);
-        latestMergedSequence.put(tableId, latestMergedSequencedNum);
-        // latestSeenSequence will replace the latestMergedSequence at the end of flush()
-        // set this default value to avoid dup query of max merged sequence num in next `flush()`
-        latestSeenSequence.put(tableId, latestMergedSequencedNum);
-      }
-
-      // it's possible that some previous events were merged to target table but offset were not committed
-      // because offset is committed when the whole batch of all the tables were merged.
-      // so it's possible we see an event that was already merged to target table
-      if (sequenceNumber > latestMergedSequencedNum) {
-        latestSeenSequence.put(tableId, sequenceNumber);
-      }
-    }
 
     latestOffset = event.getOffset();
-    latestSequenceNum = sequenceNumber;
+
     if (LOG.isTraceEnabled()) {
       LOG.trace("DDL offset: {} seq num: {}", latestOffset.get(), latestSequenceNum);
     }


### PR DESCRIPTION
sequence number is used to record the latest DML event applied in the target database. assigning sequence number to DDL event will cause some problem in some cases , see https://cdap.atlassian.net/jira/software/c/projects/CDAP/issues/CDAP-17586 for details.

so we have https://github.com/data-integrations/delta/pull/136 to not assign sequence number to DDL event, correspondingly , we don't deal with DDL sequence number in BQ plugin