### PR TITLE
CDAP-18002 persist direct loading in progress state in boolean

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -608,12 +608,12 @@ public class BigQueryEventConsumer implements EventConsumer {
         if (blob.isSnapshotOnly()) {
           context.putState(String.format(DIRECT_LOADING_IN_PROGRESS_PREFIX + "%s-%s", blob.getDataset(),
                                          blob.getTable()),
-                           Bytes.toBytes("true"));
+                           Bytes.toBytes(true));
           directLoadToTarget(blob);
         } else {
           context.putState(String.format(DIRECT_LOADING_IN_PROGRESS_PREFIX + "%s-%s", blob.getDataset(),
                                          blob.getTable()),
-                           Bytes.toBytes("false"));
+                           Bytes.toBytes(false));
           mergeTableChanges(blob);
         }
         return null;


### PR DESCRIPTION
the state was read as boolean and written as string, which caused below exception 
java.lang.IllegalArgumentException: Array has wrong size: 4
	at io.cdap.cdap.api.common.Bytes.toBoolean(Bytes.java:415) ~[na:na]
	at io.cdap.delta.bigquery.BigQueryEventConsumer.handleDDL(BigQueryEventConsumer.java:367) ~[1621448876368-

make them consistent