### PR TITLE
Add user provided column names in backtick to handle cases where rese…

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryUtils.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryUtils.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
  */
 public final class BigQueryUtils {
   private static final int MAX_LENGTH = 1024;
+  static final String BACKTICK = "`";
   // according to big query dataset and table naming convention, valid name should only contain letters (upper or
   // lower case), numbers, and underscores
   private static final String VALID_NAME_REGEX = "[\\w]+";
@@ -63,8 +64,8 @@ public final class BigQueryUtils {
                                    datasetName != null ? normalize(datasetName) : normalize(table.getDatabase()),
                                    normalize(table.getTable()));
       if (bigQuery.getTable(tableId) != null) {
-        maxSequenceNumQueryPerTable.add(String.format("SELECT MAX(_sequence_num) as max_sequence_num FROM %s.%s",
-                                                      tableId.getDataset(), tableId.getTable()));
+        maxSequenceNumQueryPerTable.add(String.format("SELECT MAX(_sequence_num) as max_sequence_num FROM %s",
+                                                      wrapInBackTick(tableId.getDataset(), tableId.getTable())));
       }
     }
 
@@ -93,7 +94,8 @@ public final class BigQueryUtils {
       return 0L;
     }
 
-    String query = String.format("SELECT MAX(_sequence_num) FROM %s.%s", tableId.getDataset(), tableId.getTable());
+    String query = String.format("SELECT MAX(_sequence_num) FROM %s",
+                                 wrapInBackTick(tableId.getDataset(), tableId.getTable()));
     return executeAggregateQuery(bigQuery, query, encryptionConfig);
   }
 
@@ -138,5 +140,9 @@ public final class BigQueryUtils {
       name = name.substring(0, MAX_LENGTH);
     }
     return name;
+  }
+
+  static String wrapInBackTick(String datasetName, String tableName) {
+    return BACKTICK + datasetName + "." + tableName + BACKTICK;
   }
 }

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
@@ -92,7 +92,8 @@ public class BigQueryEventConsumerTest {
     Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
     Schema.Field.of("created", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
     Schema.Field.of("bday", Schema.of(Schema.LogicalType.DATE)),
-    Schema.Field.of("score", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))));
+    Schema.Field.of("score", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+    Schema.Field.of("partition", Schema.nullableOf(Schema.of(Schema.Type.INT))));
 
   private static Storage storage;
   private static BigQuery bigQuery;
@@ -319,7 +320,8 @@ public class BigQueryEventConsumerTest {
                         Schema.Field.of("bday", Schema.nullableOf(Schema.of(Schema.LogicalType.DATE))),
                         // add a new nullable age field
                         Schema.Field.of("age", Schema.nullableOf(Schema.of(Schema.Type.INT))),
-                        Schema.Field.of("score", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))));
+                        Schema.Field.of("score", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
+                        Schema.Field.of("partition", Schema.nullableOf(Schema.of(Schema.Type.INT))));
       DDLEvent alterEvent = DDLEvent.builder()
         .setOperation(DDLOperation.Type.ALTER_TABLE)
         .setDatabaseName(dataset)
@@ -344,6 +346,8 @@ public class BigQueryEventConsumerTest {
       Assert.assertEquals(Field.Mode.NULLABLE, bqFields.get("age").getMode());
       Assert.assertEquals(LegacySQLTypeName.FLOAT, bqFields.get("score").getType());
       Assert.assertEquals(Field.Mode.NULLABLE, bqFields.get("score").getMode());
+      Assert.assertEquals(LegacySQLTypeName.INTEGER, bqFields.get("partition").getType());
+      Assert.assertEquals(Field.Mode.NULLABLE, bqFields.get("partition").getMode());
     } finally {
       cleanupTest(bucket, dataset, eventConsumer);
     }
@@ -404,6 +408,7 @@ public class BigQueryEventConsumerTest {
       .setTimestamp("created", ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
       .setDate("bday", LocalDate.ofEpochDay(0))
       .set("score", 0.0d)
+      .set("partition", 1)
       .build();
     for (String tableName : tableNames) {
       DMLEvent insert1Event = DMLEvent.builder()
@@ -452,12 +457,14 @@ public class BigQueryEventConsumerTest {
       Assert.assertEquals(0L, row.get("created").getTimestampValue());
       Assert.assertEquals("1970-01-01", row.get("bday").getStringValue());
       Assert.assertEquals(0.0d, row.get("score").getDoubleValue(), 0.000001d);
+      Assert.assertEquals(1, row.get("partition").getLongValue());
       row = iter.next();
       Assert.assertEquals(1L, row.get("id").getLongValue());
       Assert.assertEquals("bob", row.get("name").getStringValue());
       Assert.assertEquals(TimeUnit.SECONDS.toMicros(86400), row.get("created").getTimestampValue());
       Assert.assertEquals("1970-01-02", row.get("bday").getStringValue());
       Assert.assertEquals(1.0d, row.get("score").getDoubleValue(), 0.000001d);
+      Assert.assertTrue(row.get("partition").isNull());
       // staging table should be cleaned up
       Assert.assertNull(bigQuery.getTable(TableId.of(dataset, STAGING_TABLE_PREFIX + tableName)));
     }
@@ -468,6 +475,7 @@ public class BigQueryEventConsumerTest {
       .setTimestamp("created", insert1.getTimestamp("created"))
       .setDate("bday", insert1.getDate("bday"))
       .set("score", insert1.get("score"))
+      .set("partition", insert1.get("partition"))
       .build();
     for (String tableName : tableNames) {
       DMLEvent updateEvent = DMLEvent.builder()
@@ -505,6 +513,7 @@ public class BigQueryEventConsumerTest {
       Assert.assertEquals(0L, row.get("created").getTimestampValue());
       Assert.assertEquals("1970-01-01", row.get("bday").getStringValue());
       Assert.assertEquals(0.0d, row.get("score").getDoubleValue(), 0.000001d);
+      Assert.assertEquals(1L, row.get("partition").getLongValue());
       // staging table should be cleaned up
       Assert.assertNull(bigQuery.getTable(TableId.of(dataset, STAGING_TABLE_PREFIX + tableName)));
     }


### PR DESCRIPTION
…rved keywords in BigQuery such as partition is used as a field in the source table.

cherry-pick #124 to release/0.3 branch.