### PR TITLE
Add user provided column names in backtick to handle cases where rese…

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -969,7 +969,8 @@ public class BigQueryEventConsumer implements EventConsumer {
   }
 
   static String createDiffQuery(TableId stagingTable, List<String> primaryKeys, long batchId,
-    Long latestSequenceNumInTargetTable, boolean sourceRowIdSupported, SourceProperties.Ordering sourceEventsOrdering) {
+                                Long latestSequenceNumInTargetTable, boolean sourceRowIdSupported,
+                                SourceProperties.Ordering sourceEventsOrdering) {
     String joinCondition;
     String whereClause;
     /*
@@ -1006,11 +1007,11 @@ public class BigQueryEventConsumer implements EventConsumer {
       whereClause = " B._row_id IS NULL ";
     } else {
       joinCondition = primaryKeys.stream()
-        .map(name -> String.format("A.%s = B._before_%s", name, name))
+        .map(name -> String.format("A.`%s` = B.`_before_%s`", name, name))
         .collect(Collectors.joining(" AND "));
 
       whereClause = primaryKeys.stream()
-        .map(name -> String.format("B._before_%s IS NULL", name))
+        .map(name -> String.format("B.`_before_%s` IS NULL", name))
         .collect(Collectors.joining(" AND "));
     }
 
@@ -1022,11 +1023,11 @@ public class BigQueryEventConsumer implements EventConsumer {
         Constants.SOURCE_TIMESTAMP, Constants.SEQUENCE_NUM);
     }
     return "SELECT A.* FROM\n" +
-      "(SELECT * FROM " + stagingTable.getDataset() + "." + stagingTable.getTable() +
+      "(SELECT * FROM " + BigQueryUtils.wrapInBackTick(stagingTable.getDataset(), stagingTable.getTable()) +
       " WHERE _batch_id = " + batchId +
       " AND _sequence_num > " + latestSequenceNumInTargetTable + ") as A\n" +
       "LEFT OUTER JOIN\n" +
-      "(SELECT * FROM " + stagingTable.getDataset() + "." + stagingTable.getTable() +
+      "(SELECT * FROM " + BigQueryUtils.wrapInBackTick(stagingTable.getDataset(), stagingTable.getTable()) +
       " WHERE _batch_id = " + batchId +
       " AND _sequence_num > " + latestSequenceNumInTargetTable + ") as B\n" +
       "ON " + joinCondition +
@@ -1093,7 +1094,7 @@ public class BigQueryEventConsumer implements EventConsumer {
     } else {
       // if source doesn't support row Id, we use primary keys to match the row
       mergeCondition = primaryKeys.stream()
-        .map(name -> String.format("T.%s = D._before_%s", name, name))
+        .map(name -> String.format("T.`%s` = D.`_before_%s`", name, name))
         .collect(Collectors.joining(" AND "));
 
     }
@@ -1142,7 +1143,7 @@ public class BigQueryEventConsumer implements EventConsumer {
     }
 
     String mergeQuery = "MERGE " +
-      targetTableId.getDataset() + "." + targetTableId.getTable() + " as T\n" +
+      BigQueryUtils.wrapInBackTick(targetTableId.getDataset(), targetTableId.getTable()) + " as T\n" +
       "USING (" + diffQuery + ") as D\n" +
       "ON " + mergeCondition + "\n" +
       "WHEN MATCHED AND D._op = \"DELETE\" " + updateAndDeleteCondition + "THEN\n" +
@@ -1157,7 +1158,7 @@ public class BigQueryEventConsumer implements EventConsumer {
       targetSchema.getFields().stream()
         .filter(predicate)
         .map(Schema.Field::getName)
-        .map(name -> String.format("%s = D.%s", name, name))
+        .map(name -> String.format("`%s` = D.`%s`", name, name))
         // explicitly set "_is_deleted" to null for the case when this row was previously deleted and the
         // "_is_deleted" column was set to "true" and now a new insert is to insert the same row , we need to
         // reset "_is_deleted" back to null.
@@ -1166,12 +1167,12 @@ public class BigQueryEventConsumer implements EventConsumer {
       "  INSERT (" +
       targetSchema.getFields().stream()
         .filter(predicate)
-        .map(Schema.Field::getName)
+        .map(field -> BigQueryUtils.BACKTICK + field.getName() + BigQueryUtils.BACKTICK)
         .collect(Collectors.joining(", ")) +
       ") VALUES (" +
       targetSchema.getFields().stream()
         .filter(predicate)
-        .map(Schema.Field::getName)
+        .map(field -> BigQueryUtils.BACKTICK + field.getName() + BigQueryUtils.BACKTICK)
         .collect(Collectors.joining(", ")) + ")";
 
     if (sourceEventOrdering == SourceProperties.Ordering.UN_ORDERED) {
@@ -1179,16 +1180,15 @@ public class BigQueryEventConsumer implements EventConsumer {
         "  INSERT (" +
         targetSchema.getFields().stream()
           .filter(predicate)
-          .map(Schema.Field::getName)
+          .map(field -> BigQueryUtils.BACKTICK + field.getName() + BigQueryUtils.BACKTICK)
           .collect(Collectors.joining(", ")) +
         ", " + Constants.IS_DELETED + ") VALUES (" +
         targetSchema.getFields().stream()
           .filter(predicate)
-          .map(Schema.Field::getName)
+          .map(field -> BigQueryUtils.BACKTICK + field.getName() + BigQueryUtils.BACKTICK)
           .collect(Collectors.joining(", ")) + ", true)";
     }
     return mergeQuery;
-
   }
 
   private void runWithRetries(ContextualRunnable runnable, long retryDelay, String dataset, String schema, String table,


### PR DESCRIPTION
…rved keywords in BigQuery such as partition is used as a field in the source table.

cherry-pick #124 to develop.