### PR TITLE
Updated table name validation to work with all valid characters

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryAssessor.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryAssessor.java
@@ -107,9 +107,9 @@ public class BigQueryAssessor implements TableAssessor<StandardizedTableDetail> 
     }
 
     String datasetName = this.datasetName == null ? dbName : this.datasetName;
-    String normalizedDatasetName = BigQueryUtils.normalizeDatasetOrTableName(datasetName);
-    String normalizedTableName = BigQueryUtils.normalizeDatasetOrTableName(tableName);
-    String normalizedStagingTableName = BigQueryUtils.normalizeDatasetOrTableName(stagingTableName);
+    String normalizedDatasetName = BigQueryUtils.normalizeDatasetName(datasetName);
+    String normalizedTableName = BigQueryUtils.normalizeTableName(tableName);
+    String normalizedStagingTableName = BigQueryUtils.normalizeTableName(stagingTableName);
     if (!datasetName.equals(normalizedDatasetName)) {
       //such problem should not prevent draft to be deployed
       problems.add(

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -277,11 +277,11 @@ public class BigQueryEventConsumer implements EventConsumer {
     DDLEvent event = sequencedEvent.getEvent();
     DDLOperation ddlOperation = event.getOperation();
     String normalizedDatabaseName = datasetName == null ?
-      BigQueryUtils.normalizeDatasetOrTableName(event.getOperation().getDatabaseName()) :
-      BigQueryUtils.normalizeDatasetOrTableName(datasetName);
-    String normalizedTableName = BigQueryUtils.normalizeDatasetOrTableName(ddlOperation.getTableName());
+      BigQueryUtils.normalizeDatasetName(event.getOperation().getDatabaseName()) :
+      BigQueryUtils.normalizeDatasetName(datasetName);
+    String normalizedTableName = BigQueryUtils.normalizeTableName(ddlOperation.getTableName());
     String normalizedStagingTableName = normalizedTableName == null ? null :
-      BigQueryUtils.normalizeDatasetOrTableName(stagingTablePrefix + normalizedTableName);
+      BigQueryUtils.normalizeTableName(stagingTablePrefix + normalizedTableName);
 
     runWithRetries(ctx -> handleDDL(event, normalizedDatabaseName, normalizedTableName, normalizedStagingTableName),
                    baseRetryDelay,
@@ -547,9 +547,9 @@ public class BigQueryEventConsumer implements EventConsumer {
     }
     DMLEvent event = sequencedEvent.getEvent();
     String normalizedDatabaseName = datasetName == null ?
-      BigQueryUtils.normalizeDatasetOrTableName(event.getOperation().getDatabaseName()) :
-      BigQueryUtils.normalizeDatasetOrTableName(datasetName);
-    String normalizedTableName = BigQueryUtils.normalizeDatasetOrTableName(event.getOperation().getTableName());
+      BigQueryUtils.normalizeDatasetName(event.getOperation().getDatabaseName()) :
+      BigQueryUtils.normalizeDatasetName(datasetName);
+    String normalizedTableName = BigQueryUtils.normalizeTableName(event.getOperation().getTableName());
     DMLEvent normalizedDMLEvent = BigQueryUtils.normalize(event)
       .setDatabaseName(normalizedDatabaseName)
       .setTableName(normalizedTableName)
@@ -676,7 +676,7 @@ public class BigQueryEventConsumer implements EventConsumer {
   }
 
   private void mergeTableChanges(TableBlob blob) throws DeltaFailureException, InterruptedException {
-    String normalizedStagingTableName = BigQueryUtils.normalizeDatasetOrTableName(stagingTablePrefix + blob.getTable());
+    String normalizedStagingTableName = BigQueryUtils.normalizeTableName(stagingTablePrefix + blob.getTable());
     TableId stagingTableId = TableId.of(project, blob.getDataset(), normalizedStagingTableName);
     long retryDelay = Math.min(91, context.getMaxRetrySeconds()) - 1;
     runWithRetries(runContext -> loadTable(stagingTableId, blob, false, runContext.getAttemptCount()),

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryUtilsTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryUtilsTest.java
@@ -91,22 +91,43 @@ public class BigQueryUtilsTest {
     }
 
     @Test
-    public void testNormalizeDataSetOrTableName() {
+    public void testNormalizeDatasetName() {
       // only contains number and letter
-      assertEquals("a2fs", BigQueryUtils.normalizeDatasetOrTableName("a2fs"));
+      assertEquals("a2fs", BigQueryUtils.normalizeDatasetName("a2fs"));
       // only contains number and letter start with number
-      assertEquals("2fas", BigQueryUtils.normalizeDatasetOrTableName("2fas"));
+      assertEquals("2fas", BigQueryUtils.normalizeDatasetName("2fas"));
       // only contains number and letter and length is 1024
       String name = Strings.repeat("a1", 512);
-      assertEquals(name, BigQueryUtils.normalizeDatasetOrTableName(name));
+      assertEquals(name, BigQueryUtils.normalizeDatasetName(name));
       // only contains number and letter and length is 1026
       name = Strings.repeat("a1", 513);
-      assertEquals(name.substring(0, 1024), BigQueryUtils.normalizeDatasetOrTableName(name));
+      assertEquals(name.substring(0, 1024), BigQueryUtils.normalizeDatasetName(name));
       // contains invalid character
-      assertEquals("ab_c", BigQueryUtils.normalizeDatasetOrTableName("ab?/c"));
-      // contains space
-      assertEquals("a2_fs", BigQueryUtils.normalizeFieldName("a2 fs"));
+      assertEquals("ab_c", BigQueryUtils.normalizeDatasetName("ab?/c"));
+      // contains space (invalid character)
+      assertEquals("a2_fs", BigQueryUtils.normalizeDatasetName("a2 fs"));
+      // contains hyphen (invalid character)
+      assertEquals("a2_fs", BigQueryUtils.normalizeDatasetName("a2-fs"));
+    }
 
+    @Test
+    public void testNormalizeTableName() {
+      // only contains number and letter
+      assertEquals("a2fs", BigQueryUtils.normalizeTableName("a2fs"));
+      // only contains number and letter start with number
+      assertEquals("2fas", BigQueryUtils.normalizeTableName("2fas"));
+      // only contains number and letter and length is 1024
+      String name = Strings.repeat("a1", 512);
+      assertEquals(name, BigQueryUtils.normalizeTableName(name));
+      // only contains number and letter and length is 1026
+      name = Strings.repeat("a1", 513);
+      assertEquals(name.substring(0, 1024), BigQueryUtils.normalizeTableName(name));
+      // contains invalid character
+      assertEquals("ab_c", BigQueryUtils.normalizeTableName("ab?c"));
+      // contains space (this is valid)
+      assertEquals("a2 fs", BigQueryUtils.normalizeTableName("a2 fs"));
+      // contains hyphen (this is valid)
+      assertEquals("a2-fs", BigQueryUtils.normalizeTableName("a2-fs"));
     }
 
     @Test


### PR DESCRIPTION
Previously, BigQuery table names could only contain letters, numbers, and underscores. The valid character set has since been expanded ([reference](https://cloud.google.com/bigquery/docs/tables#table_naming)), so normalization currently unnecessarily changes some otherwise valid table names.

This PR fixes this issue by updating the regex used to normalize table names. I also added relevant unit tests.

Relevant Jira issue: [PLUGIN-1325](https://cdap.atlassian.net/browse/PLUGIN-1325).

[PR #1090](https://github.com/data-integrations/google-cloud/pull/1090) in `google-cloud` is related.