### PR TITLE
Bug/cdap 19442 - normalize column names in big query schema 

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryUtils.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryUtils.java
@@ -211,7 +211,7 @@ public final class BigQueryUtils {
       normalizedEventBuilder.setRow(normalize(event.getRow()));
     }
     if (event.getPreviousRow() != null) {
-      normalizedEventBuilder.setPreviousRow(normalize(event.getRow()));
+      normalizedEventBuilder.setPreviousRow(normalize(event.getPreviousRow()));
     }
     return normalizedEventBuilder;
   }

--- a/src/main/java/io/cdap/delta/bigquery/Schemas.java
+++ b/src/main/java/io/cdap/delta/bigquery/Schemas.java
@@ -115,7 +115,7 @@ public class Schemas {
   }
 
   private static Field convertToBigQueryField(Schema.Field field) {
-    String name = field.getName();
+    String normalizedName = BigQueryUtils.normalizeFieldName(field.getName());
     boolean isNullable = field.getSchema().isNullable();
     Schema fieldSchema = field.getSchema();
     fieldSchema = isNullable ? fieldSchema.getNonNullable() : fieldSchema;
@@ -127,9 +127,9 @@ public class Schemas {
       if (bqType == null) {
         throw new IllegalArgumentException(
           String.format("Field '%s' is of type '%s', which is not supported in BigQuery.",
-                        name, logicalType.getToken()));
+                        normalizedName, logicalType.getToken()));
       }
-      return Field.newBuilder(name, bqType).setMode(fieldMode).build();
+      return Field.newBuilder(normalizedName, bqType).setMode(fieldMode).build();
     }
 
     Field output;
@@ -141,20 +141,20 @@ public class Schemas {
       if (bqType == null) {
         throw new IllegalArgumentException(
           String.format("Field '%s' is an array of '%s', which is not supported in BigQuery.",
-                        name, logicalType.getToken()));
+                        normalizedName, logicalType.getToken()));
       }
-      output = Field.newBuilder(name, bqType).setMode(Field.Mode.REPEATED).build();
+      output = Field.newBuilder(normalizedName, bqType).setMode(Field.Mode.REPEATED).build();
     } else if (type == Schema.Type.RECORD) {
       List<Field> subFields = convertFields(fieldSchema.getFields());
-      output = Field.newBuilder(name, StandardSQLTypeName.STRUCT, FieldList.of(subFields)).build();
+      output = Field.newBuilder(normalizedName, StandardSQLTypeName.STRUCT, FieldList.of(subFields)).build();
     } else {
       StandardSQLTypeName bqType = convertType(type);
       if (bqType == null) {
         throw new IllegalArgumentException(
           String.format("Field '%s' is of type '%s', which is not supported in BigQuery.",
-                        name, type.name().toLowerCase()));
+                        normalizedName, type.name().toLowerCase()));
       }
-      output = Field.newBuilder(name, bqType).setMode(fieldMode).build();
+      output = Field.newBuilder(normalizedName, bqType).setMode(fieldMode).build();
     }
     return output;
   }


### PR DESCRIPTION
This PR is opened to address JIRA [CDAP-19442](https://cdap.atlassian.net/browse/CDAP-19442)

Currently normalization is not applied to column names and clustering fields, so we will see an exception when creating table with invalid format (eg, column name that as dash in it) similarly during replication job tries to create such tables. The way to fix this is to apply the existing BigQueryUtils.normalizeFieldName when converting schema to BigQuery schema, so that all fields are in line with BigQuery requirements.

For validation, a new unit test has been added to make sure invalid column fields/clustering fields are handled properly. 