### PR TITLE
CDAP-19599 Handle empty data from state store when processing DDL event

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -350,7 +350,7 @@ public class BigQueryEventConsumer implements EventConsumer {
         // because of some failure scenario. Delete the existing table if any.
         byte[] state = context.getState(String.format(DIRECT_LOADING_IN_PROGRESS_PREFIX + "%s-%s",
                                                       normalizedDatabaseName, normalizedTableName));
-        if (table != null && state != null && Bytes.toBoolean(state)) {
+        if (table != null && state != null && state.length != 0 && Bytes.toBoolean(state)) {
           bigQuery.delete(tableId);
         }
         List<String> primaryKeys = event.getPrimaryKey();


### PR DESCRIPTION
State store returns an empty byte array when no state exists for the key https://github.com/data-integrations/delta/blob/develop/delta-app/src/main/java/io/cdap/delta/store/DBReplicationStateStore.java#L87, and hence null check is not enough to detect non existent state.