### PR TITLE
CDAP-19939 Fix handling of high precision datetime

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/StructuredRecordToJson.java
+++ b/src/main/java/io/cdap/delta/bigquery/StructuredRecordToJson.java
@@ -62,7 +62,6 @@ public final class StructuredRecordToJson {
    */
   private static final Pattern LOGICAL_DATE_PATTERN =
     Pattern.compile("\\d{4}-\\d{1,2}-\\d{1,2}([ T]\\d{1,2}:\\d{1,2}:\\d{1,2}(\\.(\\d+))?)?");
-  private static final int LOGICAL_DATE_WITH_TIMEFRACTION_GROUP_COUNT = 3;
   private static final int TIME_FRACTION_GROUP = 3;
 
   /**
@@ -210,17 +209,15 @@ public final class StructuredRecordToJson {
   private static String checkAndTrimToMaxSupportedPrecision(String strValue) {
     Matcher matcher = LOGICAL_DATE_PATTERN.matcher(strValue);
     if (matcher.matches()) {
-      if (matcher.groupCount() == LOGICAL_DATE_WITH_TIMEFRACTION_GROUP_COUNT) {
-        String timeFraction = matcher.group(TIME_FRACTION_GROUP);
-        //matcher.group returns null for a group if an optional group did not exist in the string
-        if (timeFraction != null) {
-          if (timeFraction.length() > MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION) {
-            //Trim the time fraction to max supported precision
-            String trimmedTimeFraction = timeFraction.substring(0, MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION);
-            strValue = new StringBuilder(strValue)
-              .replace(matcher.start(TIME_FRACTION_GROUP), matcher.end(TIME_FRACTION_GROUP), trimmedTimeFraction)
-              .toString();
-          }
+      String timeFraction = matcher.group(TIME_FRACTION_GROUP);
+      //matcher.group returns null for a group if an optional group did not exist in the string
+      if (timeFraction != null) {
+        if (timeFraction.length() > MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION) {
+          //Trim the time fraction to max supported precision
+          String trimmedTimeFraction = timeFraction.substring(0, MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION);
+          strValue = new StringBuilder(strValue)
+            .replace(matcher.start(TIME_FRACTION_GROUP), matcher.end(TIME_FRACTION_GROUP), trimmedTimeFraction)
+            .toString();
         }
       }
     } else {

--- a/src/main/java/io/cdap/delta/bigquery/StructuredRecordToJson.java
+++ b/src/main/java/io/cdap/delta/bigquery/StructuredRecordToJson.java
@@ -223,7 +223,7 @@ public final class StructuredRecordToJson {
     } else {
       //Don't throw exception for now as we might be missing some scenario in the format
       //Let it fail during BigQuery insert in case of wrong format
-      LOG.error("Invalid value {} for DATETIME type, it should match the " +
+      LOG.warn("Invalid value {} for DATETIME type, it should match the " +
                   "format YYYY-[M]M-[D]D[( |T)[H]H:[M]M:[S]S[.F]]", strValue);
     }
     return strValue;

--- a/src/main/java/io/cdap/delta/bigquery/StructuredRecordToJson.java
+++ b/src/main/java/io/cdap/delta/bigquery/StructuredRecordToJson.java
@@ -20,6 +20,8 @@ import com.google.gson.stream.JsonWriter;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -39,22 +41,36 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 /**
  * Util class to convert structured record into json.
  */
 public final class StructuredRecordToJson {
+  private static final Logger LOG = LoggerFactory.getLogger(StructuredRecordToJson.class);
+
   private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
   private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS");
   // array of arrays and map of arrays are not supported by big query
   private static final Set<Schema.Type> UNSUPPORTED_ARRAY_TYPES = ImmutableSet.of(Schema.Type.ARRAY, Schema.Type.MAP);
 
+  private static final int MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION = 6;
+  /* BigQuery format for DateTime: YYYY-[M]M-[D]D[( |T)[H]H:[M]M:[S]S[.F]]
+   * [.F]: Up to six fractional digits (microsecond precision)
+   */
+  private static final Pattern LOGICAL_DATE_PATTERN =
+    Pattern.compile("\\d{4}-\\d{1,2}-\\d{1,2}([ T]\\d{1,2}:\\d{1,2}:\\d{1,2}(\\.(\\d+))?)?");
+  private static final int LOGICAL_DATE_WITH_TIMEFRACTION_GROUP_COUNT = 3;
+  private static final int TIME_FRACTION_GROUP = 3;
+
   /**
    * Writes object and writes to json writer.
-   * @param writer json writer to write the object to
-   * @param name name of the field to be written
-   * @param object object to be written
+   *
+   * @param writer      json writer to write the object to
+   * @param name        name of the field to be written
+   * @param object      object to be written
    * @param fieldSchema field schema to be written
    */
   public static void write(JsonWriter writer, String name, Object object, Schema fieldSchema) throws IOException {
@@ -143,8 +159,14 @@ public final class StructuredRecordToJson {
           writer.value(Objects.requireNonNull(getDecimal((byte[]) object, schema)).toPlainString());
           break;
         case DATETIME:
-          //datetime should be already an ISO-8601 string
-          writer.value(Objects.requireNonNull(object.toString()));
+          String strValue = object.toString();
+          // Datetime should be already an ISO-8601 string
+          // But BigQuery format is stricter than ISO-8601 and does not support Zone and Offset
+          // Hence it is more closer to DateTimeFormatter.ISO_LOCAL_DATE_TIME but with microsecond precision
+          // Check if the value matches expected format for DateTime and trim time fraction to
+          // MAX_TIME_FRACTION_PRECISION if it exceeds it
+          strValue = checkAndTrimToMaxSupportedPrecision(strValue);
+          writer.value(Objects.requireNonNull(strValue));
           break;
         default:
           throw new IllegalStateException(
@@ -183,6 +205,31 @@ public final class StructuredRecordToJson {
         throw new IllegalStateException(String.format("Field '%s' is of unsupported type '%s'",
                                                       name, schema.getType()));
     }
+  }
+
+  private static String checkAndTrimToMaxSupportedPrecision(String strValue) {
+    Matcher matcher = LOGICAL_DATE_PATTERN.matcher(strValue);
+    if (matcher.matches()) {
+      if (matcher.groupCount() == LOGICAL_DATE_WITH_TIMEFRACTION_GROUP_COUNT) {
+        String timeFraction = matcher.group(TIME_FRACTION_GROUP);
+        //matcher.group returns null for a group if an optional group did not exist in the string
+        if (timeFraction != null) {
+          if (timeFraction.length() > MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION) {
+            //Trim the time fraction to max supported precision
+            String trimmedTimeFraction = timeFraction.substring(0, MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION);
+            strValue = new StringBuilder(strValue)
+              .replace(matcher.start(TIME_FRACTION_GROUP), matcher.end(TIME_FRACTION_GROUP), trimmedTimeFraction)
+              .toString();
+          }
+        }
+      }
+    } else {
+      //Don't throw exception for now as we might be missing some scenario in the format
+      //Let it fail during BigQuery insert in case of wrong format
+      LOG.error("Invalid value {} for DATETIME type, it should match the " +
+                  "format YYYY-[M]M-[D]D[( |T)[H]H:[M]M:[S]S[.F]]", strValue);
+    }
+    return strValue;
   }
 
   private static void writeArray(JsonWriter writer,

--- a/src/main/java/io/cdap/delta/bigquery/StructuredRecordToJson.java
+++ b/src/main/java/io/cdap/delta/bigquery/StructuredRecordToJson.java
@@ -211,20 +211,18 @@ public final class StructuredRecordToJson {
     if (matcher.matches()) {
       String timeFraction = matcher.group(TIME_FRACTION_GROUP);
       //matcher.group returns null for a group if an optional group did not exist in the string
-      if (timeFraction != null) {
-        if (timeFraction.length() > MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION) {
-          //Trim the time fraction to max supported precision
-          String trimmedTimeFraction = timeFraction.substring(0, MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION);
-          strValue = new StringBuilder(strValue)
-            .replace(matcher.start(TIME_FRACTION_GROUP), matcher.end(TIME_FRACTION_GROUP), trimmedTimeFraction)
-            .toString();
-        }
+      if (timeFraction != null && timeFraction.length() > MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION) {
+        //Trim the time fraction to max supported precision
+        String trimmedTimeFraction = timeFraction.substring(0, MAX_LOGICAL_DATE_TIME_FRACTION_PRECISION);
+        strValue = new StringBuilder(strValue)
+          .replace(matcher.start(TIME_FRACTION_GROUP), matcher.end(TIME_FRACTION_GROUP), trimmedTimeFraction)
+          .toString();
       }
     } else {
       //Don't throw exception for now as we might be missing some scenario in the format
       //Let it fail during BigQuery insert in case of wrong format
       LOG.warn("Invalid value {} for DATETIME type, it should match the " +
-                  "format YYYY-[M]M-[D]D[( |T)[H]H:[M]M:[S]S[.F]]", strValue);
+                 "format YYYY-[M]M-[D]D[( |T)[H]H:[M]M:[S]S[.F]]", strValue);
     }
     return strValue;
   }

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
@@ -63,6 +63,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -84,7 +85,7 @@ import java.util.concurrent.TimeoutException;
  * Tests for BigQueryEventConsumer. In order to run these tests, service account credentials must be set in the system
  * properties. The service account must have permission to create and write to BigQuery datasets and tables,
  * as well as permission to write to GCS.
- *
+ * <p>
  * The tests create real resources in GCP and will cost some small amount of money for each run.
  */
 public class BigQueryEventConsumerTest {
@@ -93,6 +94,7 @@ public class BigQueryEventConsumerTest {
     Schema.Field.of("id", Schema.of(Schema.Type.INT)),
     Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
     Schema.Field.of("created", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
+    Schema.Field.of("updated", Schema.nullableOf(Schema.of(Schema.LogicalType.DATETIME))),
     Schema.Field.of("bday", Schema.of(Schema.LogicalType.DATE)),
     Schema.Field.of("score", Schema.nullableOf(Schema.of(Schema.Type.DOUBLE))),
     Schema.Field.of("partition", Schema.nullableOf(Schema.of(Schema.Type.INT))));
@@ -794,6 +796,8 @@ public class BigQueryEventConsumerTest {
       .set("id", 0)
       .set("name", "alice")
       .setTimestamp("created", ZonedDateTime.ofInstant(Instant.EPOCH, ZoneId.of("UTC")))
+      //check nano precision value is correctly handled, minusNanos is required otherwise zeroes in nanos are truncated
+      .setDateTime("updated", LocalDateTime.ofInstant(Instant.now(), ZoneId.of("UTC")).minusNanos(1))
       .setDate("bday", LocalDate.ofEpochDay(0))
       .set("score", 0.0d)
       .build();
@@ -814,6 +818,7 @@ public class BigQueryEventConsumerTest {
       .set("id", 1)
       .set("name", "bob")
       .setTimestamp("created", ZonedDateTime.ofInstant(Instant.ofEpochSecond(86400), ZoneId.of("UTC")))
+      .setDateTime("updated", LocalDateTime.ofInstant(Instant.now(), ZoneId.of("UTC")).minusNanos(1))
       .setDate("bday", LocalDate.ofEpochDay(1))
       .set("score", 1.0d)
       .build();

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
@@ -66,6 +66,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -818,7 +819,8 @@ public class BigQueryEventConsumerTest {
       .set("id", 1)
       .set("name", "bob")
       .setTimestamp("created", ZonedDateTime.ofInstant(Instant.ofEpochSecond(86400), ZoneId.of("UTC")))
-      .setDateTime("updated", LocalDateTime.ofInstant(Instant.now(), ZoneId.of("UTC")).minusNanos(1))
+      .setDateTime("updated", LocalDateTime.ofInstant(Instant.now().truncatedTo(ChronoUnit.SECONDS),
+                                                      ZoneId.of("UTC")))
       .setDate("bday", LocalDate.ofEpochDay(1))
       .set("score", 1.0d)
       .build();

--- a/src/test/java/io/cdap/delta/bigquery/StructuredRecordToJsonTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/StructuredRecordToJsonTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.delta.bigquery;
+
+import com.google.gson.stream.JsonWriter;
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StructuredRecordToJsonTest {
+
+  @Mock
+  private JsonWriter jsonWriter;
+
+  @Test
+  public void testWriteDateTimeNanoPrecision() throws IOException {
+    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 14:31:12.123456789",
+                                 Schema.of(Schema.LogicalType.DATETIME));
+    Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 14:31:12.123456");
+  }
+
+  @Test
+  public void testWriteDateTimeNanoPrecisionAlternateFormat() throws IOException {
+    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19T14:31:12.123456789",
+                                 Schema.of(Schema.LogicalType.DATETIME));
+    Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19T14:31:12.123456");
+  }
+
+  @Test
+  public void testWriteDateTimeHundredNanoPrecision() throws IOException {
+    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 14:31:12.1234567",
+                                 Schema.of(Schema.LogicalType.DATETIME));
+    Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 14:31:12.123456");
+  }
+
+  @Test
+  public void testWriteDateTimeMicrosecondPrecision() throws IOException {
+    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 14:31:12.123456",
+                                 Schema.of(Schema.LogicalType.DATETIME));
+    Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 14:31:12.123456");
+  }
+
+  @Test
+  public void testWriteDateTimeMillisPrecision() throws IOException {
+    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 14:31:12.123",
+                                 Schema.of(Schema.LogicalType.DATETIME));
+    Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 14:31:12.123");
+  }
+
+  @Test
+  public void testWriteDateTimeSecondPrecision() throws IOException {
+    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 14:31:12",
+                                 Schema.of(Schema.LogicalType.DATETIME));
+    Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 14:31:12");
+  }
+
+  @Test
+  public void testWriteDateTimeSecondPrecisionSingleDigit() throws IOException {
+    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 4:1:2", Schema.of(Schema.LogicalType.DATETIME));
+    Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 4:1:2");
+  }
+
+  @Test
+  public void testWriteDateTimeWithoutTime() throws IOException {
+    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19", Schema.of(Schema.LogicalType.DATETIME));
+    Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19");
+  }
+
+  @Test
+  public void testWriteDateTimeSingleDigitDate() throws IOException {
+    StructuredRecordToJson.write(jsonWriter, "updated", "2022-4-1", Schema.of(Schema.LogicalType.DATETIME));
+    Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-4-1");
+  }
+}

--- a/src/test/java/io/cdap/delta/bigquery/StructuredRecordToJsonTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/StructuredRecordToJsonTest.java
@@ -28,66 +28,63 @@ import java.io.IOException;
 @RunWith(MockitoJUnitRunner.class)
 public class StructuredRecordToJsonTest {
 
+  private static final String UPDATED_COLUMN = "updated";
+  public static final Schema DATETIME_SCHEMA = Schema.of(Schema.LogicalType.DATETIME);
+
   @Mock
   private JsonWriter jsonWriter;
 
   @Test
   public void testWriteDateTimeNanoPrecision() throws IOException {
-    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 14:31:12.123456789",
-                                 Schema.of(Schema.LogicalType.DATETIME));
+    StructuredRecordToJson.write(jsonWriter, UPDATED_COLUMN, "2022-04-19 14:31:12.123456789", DATETIME_SCHEMA);
     Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 14:31:12.123456");
   }
 
   @Test
   public void testWriteDateTimeNanoPrecisionAlternateFormat() throws IOException {
-    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19T14:31:12.123456789",
-                                 Schema.of(Schema.LogicalType.DATETIME));
+    StructuredRecordToJson.write(jsonWriter, UPDATED_COLUMN, "2022-04-19T14:31:12.123456789", DATETIME_SCHEMA);
     Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19T14:31:12.123456");
   }
 
   @Test
   public void testWriteDateTimeHundredNanoPrecision() throws IOException {
-    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 14:31:12.1234567",
-                                 Schema.of(Schema.LogicalType.DATETIME));
+    StructuredRecordToJson.write(jsonWriter, UPDATED_COLUMN, "2022-04-19 14:31:12.1234567", DATETIME_SCHEMA);
     Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 14:31:12.123456");
   }
 
   @Test
   public void testWriteDateTimeMicrosecondPrecision() throws IOException {
-    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 14:31:12.123456",
-                                 Schema.of(Schema.LogicalType.DATETIME));
+    StructuredRecordToJson.write(jsonWriter, UPDATED_COLUMN, "2022-04-19 14:31:12.123456", DATETIME_SCHEMA);
     Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 14:31:12.123456");
   }
 
   @Test
   public void testWriteDateTimeMillisPrecision() throws IOException {
-    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 14:31:12.123",
-                                 Schema.of(Schema.LogicalType.DATETIME));
+    StructuredRecordToJson.write(jsonWriter, UPDATED_COLUMN, "2022-04-19 14:31:12.123", DATETIME_SCHEMA);
     Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 14:31:12.123");
   }
 
   @Test
   public void testWriteDateTimeSecondPrecision() throws IOException {
-    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 14:31:12",
-                                 Schema.of(Schema.LogicalType.DATETIME));
+    StructuredRecordToJson.write(jsonWriter, UPDATED_COLUMN, "2022-04-19 14:31:12", DATETIME_SCHEMA);
     Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 14:31:12");
   }
 
   @Test
   public void testWriteDateTimeSecondPrecisionSingleDigit() throws IOException {
-    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19 4:1:2", Schema.of(Schema.LogicalType.DATETIME));
+    StructuredRecordToJson.write(jsonWriter, UPDATED_COLUMN, "2022-04-19 4:1:2", DATETIME_SCHEMA);
     Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19 4:1:2");
   }
 
   @Test
   public void testWriteDateTimeWithoutTime() throws IOException {
-    StructuredRecordToJson.write(jsonWriter, "updated", "2022-04-19", Schema.of(Schema.LogicalType.DATETIME));
+    StructuredRecordToJson.write(jsonWriter, UPDATED_COLUMN, "2022-04-19", DATETIME_SCHEMA);
     Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-04-19");
   }
 
   @Test
   public void testWriteDateTimeSingleDigitDate() throws IOException {
-    StructuredRecordToJson.write(jsonWriter, "updated", "2022-4-1", Schema.of(Schema.LogicalType.DATETIME));
+    StructuredRecordToJson.write(jsonWriter, UPDATED_COLUMN, "2022-4-1", DATETIME_SCHEMA);
     Mockito.verify(jsonWriter, Mockito.times(1)).value("2022-4-1");
   }
 }


### PR DESCRIPTION
Inserting datetime value with precision higher than microseconds fails in BigQuery as it supports only upto microsecond precision https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#datetime_type. 
This PR fixes the issue by trimming extra precision digits from the value when writing the record.
Note that we already show a warning to user about loss of precision during replication pipeline assessment.



