### PR TITLE
CDAP-20161: Fix BigQuery plugin does not cache primary keys after fet…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
     <logback.version>1.2.3</logback.version>
     <powermock.version>2.0.9</powermock.version>
     <jacoco.version>0.8.8</jacoco.version>
-    <commons.lang>3.12.0</commons.lang>
     <!-- Need default value when coverage is not collected -->
     <argLine />
   </properties>
@@ -153,11 +152,6 @@
       <groupId>net.jodah</groupId>
       <artifactId>failsafe</artifactId>
       <version>${failsafe.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${commons.lang}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <logback.version>1.2.3</logback.version>
     <powermock.version>2.0.9</powermock.version>
     <jacoco.version>0.8.8</jacoco.version>
+    <commons.lang>3.12.0</commons.lang>
     <!-- Need default value when coverage is not collected -->
     <argLine />
   </properties>
@@ -152,6 +153,11 @@
       <groupId>net.jodah</groupId>
       <artifactId>failsafe</artifactId>
       <version>${failsafe.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons.lang}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -60,6 +60,7 @@ import net.jodah.failsafe.FailsafeException;
 import net.jodah.failsafe.RetryPolicy;
 import net.jodah.failsafe.TimeoutExceededException;
 import net.jodah.failsafe.function.ContextualRunnable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -60,7 +60,6 @@ import net.jodah.failsafe.FailsafeException;
 import net.jodah.failsafe.RetryPolicy;
 import net.jodah.failsafe.TimeoutExceededException;
 import net.jodah.failsafe.function.ContextualRunnable;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -508,7 +508,7 @@ public class BigQueryEventConsumer implements EventConsumer {
     List<String> primaryKeys = primaryKeyStore.get(targetTableId);
     if (primaryKeys == null) {
       byte[] stateBytes = context.getState(getTableStateKey(targetTableId));
-      if (stateBytes == null) {
+      if (stateBytes == null || stateBytes.length == 0) {
         throw new DeltaFailureException(
           String.format("Primary key information for table '%s' in dataset '%s' could not be found. This can only " +
                           "happen if state was corrupted. Please create a new replicator and start again.",
@@ -516,6 +516,7 @@ public class BigQueryEventConsumer implements EventConsumer {
       }
       BigQueryTableState targetTableState = GSON.fromJson(new String(stateBytes), BigQueryTableState.class);
       primaryKeys = targetTableState.getPrimaryKeys();
+      primaryKeyStore.put(targetTableId, primaryKeys);
     }
     return primaryKeys;
   }

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -69,6 +69,7 @@ public class BigQueryConsumerTest {
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryConsumerTest.class);
   private static final String TABLE_NAME_PREFIX = "table_";
   private static final String DATABASE = "database";
+  private static final String DB_SCHEMA = "schema";
   private static final int LOAD_INTERVAL_SECONDS = 4;
   private static final String DATASET = "dataset";
   private static final String EMPTY_DATASET_NAME = "";
@@ -77,6 +78,7 @@ public class BigQueryConsumerTest {
   private static final String PRIMARY_KEY_COL = "id";
   private static final String NAME_COL = "name";
   private static final long GENERATION = 1L;
+  private static final int TABLE_COUNT = 5;
   private static final int BQ_JOB_TIME_BOUND = 2;
   private static final int MAX_RETRY_SECONDS = 10;
   private static final Random random = new Random();

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -69,7 +69,6 @@ public class BigQueryConsumerTest {
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryConsumerTest.class);
   private static final String TABLE_NAME_PREFIX = "table_";
   private static final String DATABASE = "database";
-  private static final String DB_SCHEMA = "schema";
   private static final int LOAD_INTERVAL_SECONDS = 4;
   private static final String DATASET = "dataset";
   private static final String EMPTY_DATASET_NAME = "";
@@ -78,7 +77,6 @@ public class BigQueryConsumerTest {
   private static final String PRIMARY_KEY_COL = "id";
   private static final String NAME_COL = "name";
   private static final long GENERATION = 1L;
-  private static final int TABLE_COUNT = 5;
   private static final int BQ_JOB_TIME_BOUND = 2;
   private static final int MAX_RETRY_SECONDS = 10;
   private static final Random random = new Random();


### PR DESCRIPTION
Primary keys are saved to state store and cached in memory when the plugin encounters create table DDL, but in case of pipeline restart, plugin would fetch the primary keys from state store for every merge operation for each table. Fix is to cache the primary keys first time they are fetched from state store.