### PR TITLE
CDAP-20276: Fix data inconsistency issue in case of retries in BigQuery replication plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
     <logback.version>1.2.3</logback.version>
     <powermock.version>2.0.9</powermock.version>
     <jacoco.version>0.8.8</jacoco.version>
-    <commons.lang>3.12.0</commons.lang>
     <!-- Need default value when coverage is not collected -->
     <argLine />
   </properties>
@@ -153,11 +152,6 @@
       <groupId>net.jodah</groupId>
       <artifactId>failsafe</artifactId>
       <version>${failsafe.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${commons.lang}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <logback.version>1.2.3</logback.version>
     <powermock.version>2.0.9</powermock.version>
     <jacoco.version>0.8.8</jacoco.version>
+    <commons.lang>3.12.0</commons.lang>
     <!-- Need default value when coverage is not collected -->
     <argLine />
   </properties>
@@ -152,6 +153,11 @@
       <groupId>net.jodah</groupId>
       <artifactId>failsafe</artifactId>
       <version>${failsafe.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons.lang}</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -60,6 +60,7 @@ import net.jodah.failsafe.FailsafeException;
 import net.jodah.failsafe.RetryPolicy;
 import net.jodah.failsafe.TimeoutExceededException;
 import net.jodah.failsafe.function.ContextualRunnable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -240,12 +240,12 @@ public class BigQueryConsumerTest {
                                                                     EMPTY_DATASET_NAME, false);
     eventConsumer.start();
 
-    generateInsertEvents(eventConsumer, tables, numInsertEvents);
+    generateInsertCDCEvents(eventConsumer, tables, numInsertEvents);
 
     //Wait for flush with some buffer
     Thread.sleep(TimeUnit.SECONDS.toMillis(LOAD_INTERVAL_SECONDS + 2));
 
-    generateInsertEvents(eventConsumer, tables, numInsertEvents);
+    generateInsertCDCEvents(eventConsumer, tables, numInsertEvents);
 
     //Wait for flush with some buffer
     Thread.sleep(TimeUnit.SECONDS.toMillis(LOAD_INTERVAL_SECONDS + 2));

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.ws.rs.HEAD;
 
 @PrepareForTest({AvroEventWriter.class})
 @RunWith(PowerMockRunner.class)
@@ -71,6 +72,7 @@ public class BigQueryConsumerTest {
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryConsumerTest.class);
   private static final String TABLE_NAME_PREFIX = "table_";
   private static final String DATABASE = "database";
+  private static final String DB_SCHEMA = "schema";
   private static final int LOAD_INTERVAL_SECONDS = 4;
   private static final String DATASET = "dataset";
   private static final String EMPTY_DATASET_NAME = "";

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -72,7 +72,6 @@ public class BigQueryConsumerTest {
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryConsumerTest.class);
   private static final String TABLE_NAME_PREFIX = "table_";
   private static final String DATABASE = "database";
-  private static final String DB_SCHEMA = "schema";
   private static final int LOAD_INTERVAL_SECONDS = 4;
   private static final String DATASET = "dataset";
   private static final String EMPTY_DATASET_NAME = "";


### PR DESCRIPTION
### Issue

The plugin runs following BQ jobs as part of replication pipeline

1. Load job to insert snapshot events directly to the target table
2. Load job to insert CDC events directly to the staging table
3. Query job to merge CDC events from staging to target table

In case of transient network errors just after the create job request reaches BQ, the create or check status calls for job can fail and a retry would be triggered after the retry interval (90 sec). Retry would run a new job which would lead to duplicate data in staging/target table. Duplicate data in staging table can intern lead to duplicate data in target table or pipeline failure due to error `UPDATE/MERGE must match at most one source row for each target row`

### Fix
In the retry attempt, check if there was any non failing job from the previous attempts, and only create a new job if there was none.

### Testing

- Validated failure scenarios in sandbox
- Unit tests

