### PR TITLE
CDAP-20276 -  Fix data duplication when snapshot events are replayed in case of worker restarts for Datastream replication

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -164,9 +164,6 @@ public class BigQueryEventConsumer implements EventConsumer {
   private static final Gson GSON = new Gson();
   private static final String RETAIN_STAGING_TABLE = "retain.staging.table";
   private static final String DIRECT_LOADING_IN_PROGRESS_PREFIX = "bigquery-direct-load-in-progress-";
-  public static final String MERGE_JOB_TYPE = "merge";
-  public static final String LOAD_STAGING_JOB_TYPE = "stage";
-  public static final String LOAD_TARGET_JOB_TYPE = "load";
 
   private final DeltaTargetContext context;
   private final BigQuery bigQuery;
@@ -596,7 +593,6 @@ public class BigQueryEventConsumer implements EventConsumer {
       .setTableName(normalizedTableName)
       .build();
     long sequenceNumber = sequencedEvent.getSequenceNumber();
-    gcsWriter.write(new Sequenced<>(normalizedDMLEvent, sequenceNumber));
 
     TableId tableId = TableId.of(project, normalizedDatabaseName, normalizedTableName);
 
@@ -615,6 +611,8 @@ public class BigQueryEventConsumer implements EventConsumer {
     // so it's possible we see an event that was already merged to target table
     if (sequenceNumber > latestMergedSequencedNum) {
       latestSeenSequence.put(tableId, sequenceNumber);
+      //Only write events which have not already been applied
+      gcsWriter.write(new Sequenced<>(normalizedDMLEvent, sequenceNumber));
     }
 
     latestOffset = event.getOffset();
@@ -722,6 +720,7 @@ public class BigQueryEventConsumer implements EventConsumer {
 
   private void mergeTableChanges(TableBlob blob) throws DeltaFailureException, InterruptedException {
     String normalizedStagingTableName = BigQueryUtils.normalizeTableName(stagingTablePrefix + blob.getTable());
+
     TableId stagingTableId = TableId.of(project, blob.getDataset(), normalizedStagingTableName);
     long retryDelay = Math.min(91, context.getMaxRetrySeconds()) - 1;
     runWithRetries(runContext -> loadTable(stagingTableId, blob, JobType.LOAD_STAGING, runContext.getAttemptCount()),
@@ -811,9 +810,11 @@ public class BigQueryEventConsumer implements EventConsumer {
       Clustering clustering = maxClusteringColumns <= 0 ? null : Clustering.newBuilder()
         .setFields(primaryKeys.subList(0, Math.min(maxClusteringColumns, primaryKeys.size())))
         .build();
+
+      Schema schema = jobType.isForTargetTable() ? blob.getTargetSchema() : blob.getStagingSchema();
       TableDefinition tableDefinition = StandardTableDefinition.newBuilder()
         .setLocation(bucket.getLocation())
-        .setSchema(Schemas.convert(blob.getStagingSchema()))
+        .setSchema(Schemas.convert(schema))
         .setClustering(clustering)
         .build();
       TableInfo.Builder builder = TableInfo.newBuilder(tableId, tableDefinition);

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -164,6 +164,9 @@ public class BigQueryEventConsumer implements EventConsumer {
   private static final Gson GSON = new Gson();
   private static final String RETAIN_STAGING_TABLE = "retain.staging.table";
   private static final String DIRECT_LOADING_IN_PROGRESS_PREFIX = "bigquery-direct-load-in-progress-";
+  public static final String MERGE_JOB_TYPE = "merge";
+  public static final String LOAD_STAGING_JOB_TYPE = "stage";
+  public static final String LOAD_TARGET_JOB_TYPE = "load";
 
   private final DeltaTargetContext context;
   private final BigQuery bigQuery;

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -160,8 +160,8 @@ public class BigQueryConsumerTest {
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_SECONDS, "_staging",
-                                                                    CDC, null, 2L,
-                                                                    DATASET, CDC);
+                                                                    false, null, 2L,
+                                                                    DATASET, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -207,8 +207,8 @@ public class BigQueryConsumerTest {
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_SECONDS, "_staging",
-                                                                    CDC, null, 2L,
-                                                                    EMPTY_DATASET_NAME, CDC);
+                                                                    false, null, 2L,
+                                                                    EMPTY_DATASET_NAME, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -284,8 +284,8 @@ public class BigQueryConsumerTest {
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
-                                                                    CDC, null, 2L,
-                                                                    DATASET, CDC);
+                                                                    false, null, 2L,
+                                                                    DATASET, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -349,8 +349,8 @@ public class BigQueryConsumerTest {
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
-                                                                    CDC, null, 2L,
-                                                                    DATASET, CDC);
+                                                                    false, null, 2L,
+                                                                    DATASET, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -411,8 +411,8 @@ public class BigQueryConsumerTest {
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
-                                                                    CDC, null, 2L,
-                                                                    DATASET, CDC);
+                                                                    false, null, 2L,
+                                                                    DATASET, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -473,8 +473,8 @@ public class BigQueryConsumerTest {
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
-                                                                    CDC, null, 2L,
-                                                                    DATASET, CDC);
+                                                                    false, null, 2L,
+                                                                    DATASET, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -535,8 +535,8 @@ public class BigQueryConsumerTest {
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
-                                                                    CDC, null, 2L,
-                                                                    DATASET, CDC);
+                                                                    false, null, 2L,
+                                                                    DATASET, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -588,8 +588,8 @@ public class BigQueryConsumerTest {
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
-                                                                    CDC, null, 2L,
-                                                                    DATASET, CDC);
+                                                                    false, null, 2L,
+                                                                    DATASET, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);


### PR DESCRIPTION

Skip writing to GCS if the sequence number in DML events is lower than the max sequence number present in the target BigQuery table. 