### PR TITLE
CDAP-20301: Prevent infinite retry for invalid/invalidQuery BQ errors

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/JobType.java
+++ b/src/main/java/io/cdap/delta/bigquery/JobType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.delta.bigquery;
+
+/**
+ * Job type which stores additional metadata for the job
+ */
+enum JobType {
+  LOAD_STAGING("stage", false),
+  LOAD_TARGET("load", true),
+  MERGE_TARGET("merge", true);
+
+  private final String id;
+  private final boolean forTargetTable;
+
+  JobType(String id, boolean forTargetTable) {
+    this.id = id;
+    this.forTargetTable = forTargetTable;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public boolean isForTargetTable() {
+    return forTargetTable;
+  }
+}

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -621,9 +621,10 @@ public class BigQueryConsumerTest {
     List<String> tables = getTables(numTables);
 
     Mockito.when(bigQuery.getTable(Mockito.any())).thenReturn(null);
-    BigQueryError invalidError = new BigQueryError("invalid", "loc", "error");
-    Mockito.when(bigQuery.create(Mockito.any(TableInfo.class))).thenThrow(new BigQueryException(400, "error",
-                                                                                                invalidError));
+    BigQueryError error = new BigQueryError("invalid", "loc", "error");
+    Mockito.when(bigQuery.create(Mockito.any(TableInfo.class)))
+      .thenThrow(new BigQueryException(400, "error", error));
+
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -74,6 +74,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.ws.rs.HEAD;
 
 @PrepareForTest({AvroEventWriter.class})
 @RunWith(PowerMockRunner.class)

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -74,7 +74,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import javax.ws.rs.HEAD;
 
 @PrepareForTest({AvroEventWriter.class})
 @RunWith(PowerMockRunner.class)

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -45,12 +45,15 @@ import io.cdap.delta.api.DDLEvent;
 import io.cdap.delta.api.DDLOperation;
 import io.cdap.delta.api.DMLEvent;
 import io.cdap.delta.api.DMLOperation;
+import io.cdap.delta.api.DeltaFailureException;
 import io.cdap.delta.api.DeltaTargetContext;
 import io.cdap.delta.api.Offset;
 import io.cdap.delta.api.Sequenced;
 import org.apache.avro.file.DataFileWriter;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
@@ -67,7 +70,6 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -122,6 +124,9 @@ public class BigQueryConsumerTest {
   private Job job;
   @Mock
   private DataFileWriter dataFileWriter;
+
+  @Rule
+  private ExpectedException exceptionRule = ExpectedException.none();
 
   @Before
   public void setup() throws Exception {
@@ -606,14 +611,36 @@ public class BigQueryConsumerTest {
     Mockito.verify(bigQuery, Mockito.times(1)).create(datasetIs(DATASET));
     Mockito.verify(bigQuery, Mockito.atLeastOnce()).getTable(Mockito.any(TableId.class));
     //Fetch sequence num (x2 for 2 tables), no load jobs as all events are filtered out
-    Mockito.verify(bigQuery,  Mockito.times(2)).create(Mockito.any(JobInfo.class));
+    Mockito.verify(bigQuery, Mockito.times(2)).create(Mockito.any(JobInfo.class));
     eventConsumer.stop();
   }
 
+  @Test
+  public void testPermanentFailureIsNotRetriedInProcessDDL() throws Exception {
+    int numTables = 1;
+    List<String> tables = getTables(numTables);
+
+    Mockito.when(bigQuery.getTable(Mockito.any())).thenReturn(null);
+    BigQueryError invalidError = new BigQueryError("invalid", "loc", "error");
+    Mockito.when(bigQuery.create(Mockito.any(TableInfo.class))).thenThrow(new BigQueryException(400, "error",
+                                                                                                invalidError));
+    BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
+                                                                    bigQuery, bucket, "project",
+                                                                    LOAD_INTERVAL_ONE_SECOND, "_staging",
+                                                                    false, null, 2L,
+                                                                    DATASET, false);
+    eventConsumer.start();
+    try {
+      exceptionRule.expect(DeltaFailureException.class);
+      generateDDL(eventConsumer, tables);
+    } finally {
+      Mockito.verify(bigQuery, Mockito.times(1)).create(Mockito.any(TableInfo.class));
+      eventConsumer.stop();
+    }
+  }
+
   private JobId isForAttempt(int i) {
-    return Mockito.argThat(jobId -> {
-                             return jobId.getJob().endsWith("_" + i);
-                           });
+    return Mockito.argThat(jobId -> jobId.getJob().endsWith("_" + i));
   }
 
   private void waitForFlushWithBuffer(int loadIntervalSeconds, int flushCount) throws InterruptedException {


### PR DESCRIPTION
**Current behaviour**
perform infinite retries in case of `invalid` or `invalidQuery` errors from BigQuery when processing DDL events or during load/merge jobs ([BQ Reference](https://cloud.google.com/bigquery/docs/error-messages))

**Updated behaviour**
- For permanent error when processing DDL event, fail the pipeline
- For permanent error in BQ job, fail the operation and let retry happen from the worker which can mitigate the issue as staging table is created again