### PR TITLE
Add plugin level retry when writing event to GCS as part of DML event processing

### DIFF
--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -46,7 +46,9 @@ import io.cdap.delta.api.Offset;
 import io.cdap.delta.api.Sequenced;
 import org.apache.avro.file.DataFileWriter;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
@@ -115,6 +117,8 @@ public class BigQueryConsumerTest {
   private Job job;
   @Mock
   private DataFileWriter dataFileWriter;
+  @Rule
+  private ExpectedException exceptionRule = ExpectedException.none();
 
   @Before
   public void setup() throws Exception {
@@ -126,6 +130,7 @@ public class BigQueryConsumerTest {
     Mockito.when(dataFileWriter.create(Mockito.any(org.apache.avro.Schema.class), Mockito.any(OutputStream.class)))
       .thenReturn(dataFileWriter);
     PowerMockito.whenNew(DataFileWriter.class).withAnyArguments().thenReturn(dataFileWriter);
+
 
     //Random execution time for BigQuery job
     Mockito.when(job.waitFor())
@@ -304,6 +309,39 @@ public class BigQueryConsumerTest {
 
     eventConsumer.stop();
   }
+
+  @Test
+  public void testGcsWriteInMemoryFailureRetries() throws Exception {
+    Mockito.doThrow(new IllegalStateException()).when(dataFileWriter).append(Mockito.any());
+
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set(PRIMARY_KEY_COL, random.nextInt())
+      .set(NAME_COL, "alice")
+      .build();
+
+    DMLEvent insert1Event = DMLEvent.builder()
+      .setOperationType(DMLOperation.Type.INSERT)
+      .setDatabaseName(DATABASE)
+      .setTableName(TABLE)
+      .setRow(record)
+      .build();
+
+    BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
+                                                                    bigQuery, bucket, "project",
+                                                                    LOAD_INTERVAL_ONE_SECOND, "_staging",
+                                                                    false, null, 2L,
+                                                                    DATASET, false);
+
+    try {
+      exceptionRule.expect(IllegalStateException.class);
+      eventConsumer.applyDML(new Sequenced<>(insert1Event, 0));
+    } finally {
+      //Verify that retry happens
+      Mockito.verify(dataFileWriter, Mockito.atLeast(2)).append(Mockito.any());
+      eventConsumer.stop();
+    }
+  }
+
 
   /**
    *  Test checks retry handling in case of create and get status failure for load job


### PR DESCRIPTION
- Added unit tests
