### PR TITLE
Add retry for BQ calls during plugin initialization 

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -193,6 +193,11 @@ public class BigQueryEventConsumer implements EventConsumer {
   private long latestSequenceNum;
   private Exception flushException;
   private final AtomicBoolean shouldStop;
+  private RetryPolicy<Object> gcsWriterRetryPolicy = new RetryPolicy<>()
+                                                .withMaxAttempts(25)
+                                                .withMaxDuration(Duration.of(2, ChronoUnit.MINUTES))
+                                                .withBackoff(1, 30, ChronoUnit.SECONDS)
+                                                .withJitter(0.1);
 
   private enum JobType {
     LOAD_STAGING("stage", false), LOAD_TARGET("load", true), MERGE_TARGET("merge", true);
@@ -593,11 +598,7 @@ public class BigQueryEventConsumer implements EventConsumer {
       .setTableName(normalizedTableName)
       .build();
     long sequenceNumber = sequencedEvent.getSequenceNumber();
-    Failsafe.with(new RetryPolicy<>()
-                    .withMaxAttempts(25)
-                    .withMaxDuration(Duration.of(2, ChronoUnit.MINUTES))
-                    .withBackoff(1, 30, ChronoUnit.SECONDS)
-                    .withJitter(0.1))
+    Failsafe.with(gcsWriterRetryPolicy)
             .run(() -> gcsWriter.write(new Sequenced<>(normalizedDMLEvent, sequenceNumber)));
 
     TableId tableId = TableId.of(project, normalizedDatabaseName, normalizedTableName);

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
@@ -20,6 +20,7 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.EncryptionConfiguration;
 import com.google.cloud.storage.Bucket;
@@ -41,6 +42,8 @@ import io.cdap.delta.api.DeltaTargetContext;
 import io.cdap.delta.api.EventConsumer;
 import io.cdap.delta.api.assessment.StandardizedTableDetail;
 import io.cdap.delta.api.assessment.TableAssessor;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +51,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -65,6 +73,10 @@ public class BigQueryTarget implements DeltaTarget {
   private static final String GCS_SCHEME = "gs://";
   private static final String GCP_CMEK_KEY_NAME = "gcp.cmek.key.name";
   private static final int MAX_TABLES_PER_QUERY = 1000;
+  private  static final String RATE_LIMIT_EXCEEDED_REASON = "rateLimitExceeded";
+  private static final Set<Integer> RATE_LIMIT_EXCEEDED_CODES = new HashSet<>(Arrays.asList(400, 403));
+  private  static final int BILLING_TIER_LIMIT_EXCEEDED_CODE = 400;
+  private  static final String BILLING_TIER_LIMIT_EXCEEDED_REASON = "billingTierLimitExceeded";
   private final Conf conf;
 
   @SuppressWarnings("unused")
@@ -93,9 +105,9 @@ public class BigQueryTarget implements DeltaTarget {
       .build()
       .getService();
 
-    long maximumExistingSequenceNumber =
-      BigQueryUtils.getMaximumExistingSequenceNumber(context.getAllTables(), project, conf.getDatasetName(),
-                                                     bigQuery, encryptionConfig, MAX_TABLES_PER_QUERY);
+    long maximumExistingSequenceNumber = Failsafe.with(createRetryPolicyForBq()).get(() ->
+            BigQueryUtils.getMaximumExistingSequenceNumber(context.getAllTables(), project, conf.getDatasetName(),
+                    bigQuery, encryptionConfig, MAX_TABLES_PER_QUERY));
 
     LOG.info("Found maximum sequence number {}", maximumExistingSequenceNumber);
 
@@ -125,30 +137,41 @@ public class BigQueryTarget implements DeltaTarget {
       .getService();
 
     String stagingBucketName = getStagingBucketName(conf.stagingBucket, context.getPipelineId());
-    Bucket bucket = storage.get(stagingBucketName);
-    if (bucket == null) {
-      try {
-        BucketInfo.Builder builder = BucketInfo.newBuilder(stagingBucketName);
-        if (cmekKey != null) {
-          builder.setDefaultKmsKeyName(cmekKey);
+    RetryPolicy<Object> retryPolicy = new RetryPolicy<>()
+            .withMaxAttempts(25)
+            .withMaxDuration(Duration.of(2, ChronoUnit.MINUTES))
+            .withBackoff(1, 30, ChronoUnit.SECONDS)
+            .withJitter(0.1)
+            .abortOn(throwable -> !((throwable instanceof IOException) ||
+                    (throwable instanceof StorageException && ((StorageException) throwable).isRetryable())));
+
+    Bucket bucket = Failsafe.with(retryPolicy).get(() -> {
+      Bucket b = storage.get(stagingBucketName);
+      if (b == null) {
+        try {
+          BucketInfo.Builder builder = BucketInfo.newBuilder(stagingBucketName);
+          if (cmekKey != null) {
+            builder.setDefaultKmsKeyName(cmekKey);
+          }
+          if (conf.stagingBucketLocation != null && !conf.stagingBucketLocation.trim().isEmpty()) {
+            builder.setLocation(conf.stagingBucketLocation);
+          }
+          b = storage.create(builder.build());
+        } catch (StorageException e) {
+          // It is possible that in multiple worker instances scenario
+          // bucket is created by another worker instance after this worker instance
+          // determined that the bucket does not exists. Ignore error if bucket already exists.
+          if (e.getCode() != CONFLICT) {
+            throw new IOException(
+                    String.format("Unable to create staging bucket '%s' in project '%s'. " +
+                            "Please make sure the service account has permission to create buckets, " +
+                            "or create the bucket before starting the program.", stagingBucketName, project), e);
+          }
+          b = storage.get(stagingBucketName);
         }
-        if (conf.stagingBucketLocation != null && !conf.stagingBucketLocation.trim().isEmpty()) {
-          builder.setLocation(conf.stagingBucketLocation);
-        }
-        bucket = storage.create(builder.build());
-      } catch (StorageException e) {
-        // It is possible that in multiple worker instances scenario
-        // bucket is created by another worker instance after this worker instance
-        // determined that the bucket does not exists. Ignore error if bucket already exists.
-        if (e.getCode() != CONFLICT) {
-          throw new IOException(
-            String.format("Unable to create staging bucket '%s' in project '%s'. "
-                            + "Please make sure the service account has permission to create buckets, "
-                            + "or create the bucket before starting the program.", stagingBucketName, project), e);
-        }
-        bucket = storage.get(stagingBucketName);
       }
-    }
+      return b;
+    });
 
     return new BigQueryEventConsumer(context, storage, bigQuery, bucket, project,
                                      conf.getLoadIntervalSeconds(), conf.getStagingTablePrefix(),
@@ -176,6 +199,25 @@ public class BigQueryTarget implements DeltaTarget {
   private static String stringifyPipelineId(DeltaPipelineId pipelineId) {
     return Joiner.on("-").join(STAGING_BUCKET_PREFIX, pipelineId.getNamespace(), pipelineId.getApp(),
                                pipelineId.getGeneration());
+  }
+
+  private <T> RetryPolicy<T> createRetryPolicyForBq() {
+    RetryPolicy<T> retryPolicy = new RetryPolicy<>();
+    retryPolicy.abortOn(throwable -> {
+      if (throwable instanceof BigQueryException) {
+        BigQueryException t = (BigQueryException) throwable;
+        boolean isRateLimitExceeded =  RATE_LIMIT_EXCEEDED_CODES.contains(t.getCode())
+                && t.getError().getReason().equals(RATE_LIMIT_EXCEEDED_REASON);
+        boolean isBillingTierLimitExceeded = t.getCode() == BILLING_TIER_LIMIT_EXCEEDED_CODE
+                && t.getError().getReason().equals(BILLING_TIER_LIMIT_EXCEEDED_REASON);
+        return !(t.isRetryable() || isRateLimitExceeded || isBillingTierLimitExceeded);
+      }
+      return false;
+    });
+    return retryPolicy.withMaxAttempts(25)
+            .withMaxDuration(Duration.of(2, ChronoUnit.MINUTES))
+            .withBackoff(1, 30, ChronoUnit.SECONDS)
+            .withJitter(0.1);
   }
 
   /**

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -46,7 +46,9 @@ import io.cdap.delta.api.Offset;
 import io.cdap.delta.api.Sequenced;
 import org.apache.avro.file.DataFileWriter;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
@@ -115,6 +117,8 @@ public class BigQueryConsumerTest {
   private Job job;
   @Mock
   private DataFileWriter dataFileWriter;
+  @Rule
+  private ExpectedException exceptionRule = ExpectedException.none();
 
   @Before
   public void setup() throws Exception {
@@ -126,6 +130,7 @@ public class BigQueryConsumerTest {
     Mockito.when(dataFileWriter.create(Mockito.any(org.apache.avro.Schema.class), Mockito.any(OutputStream.class)))
       .thenReturn(dataFileWriter);
     PowerMockito.whenNew(DataFileWriter.class).withAnyArguments().thenReturn(dataFileWriter);
+
 
     //Random execution time for BigQuery job
     Mockito.when(job.waitFor())
@@ -304,6 +309,39 @@ public class BigQueryConsumerTest {
 
     eventConsumer.stop();
   }
+
+  @Test
+  public void testGcsWriteInMemoryFailureRetries() throws Exception {
+    Mockito.doThrow(new IllegalStateException()).when(dataFileWriter).append(Mockito.any());
+
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set(PRIMARY_KEY_COL, random.nextInt())
+      .set(NAME_COL, "alice")
+      .build();
+
+    DMLEvent insert1Event = DMLEvent.builder()
+      .setOperationType(DMLOperation.Type.INSERT)
+      .setDatabaseName(DATABASE)
+      .setTableName(TABLE)
+      .setRow(record)
+      .build();
+
+    BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(deltaTargetContext, storage,
+                                                                    bigQuery, bucket, "project",
+                                                                    LOAD_INTERVAL_ONE_SECOND, "_staging",
+                                                                    false, null, 2L,
+                                                                    DATASET, false);
+
+    try {
+      exceptionRule.expect(IllegalStateException.class);
+      eventConsumer.applyDML(new Sequenced<>(insert1Event, 0));
+    } finally {
+      //Verify that retry happens
+      Mockito.verify(dataFileWriter, Mockito.atLeast(2)).append(Mockito.any());
+      eventConsumer.stop();
+    }
+  }
+
 
   /**
    *  Test checks retry handling in case of create and get status failure for load job

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryTargetTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryTargetTest.java
@@ -16,21 +16,93 @@
 
 package io.cdap.delta.bigquery;
 
+import com.google.auth.Credentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.EncryptionConfiguration;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.StorageOptions;
 import io.cdap.delta.api.DeltaPipelineId;
+import io.cdap.delta.api.DeltaTargetContext;
+import net.jodah.failsafe.FailsafeException;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+
 
 import static io.cdap.delta.bigquery.BigQueryTarget.STAGING_BUCKET_PREFIX;
 
 /**
  * Tests for BigQueryTarget.
  */
+@PrepareForTest({BigQueryUtils.class, BigQueryTarget.class, StorageOptions.class, BucketInfo.class})
+@RunWith(PowerMockRunner.class)
 public class BigQueryTargetTest {
+
+  private static final String GCP_CMEK_KEY_NAME = "gcp.cmek.key.name";
+  private static final String PROJECT = "project";
+  private  static final String RATE_LIMIT_EXCEEDED_REASON = "rateLimitExceeded";
+  private static final Set<Integer> RATE_LIMIT_EXCEEDED_CODES = new HashSet<>(Arrays.asList(400, 403));
+  private  static final int BILLING_TIER_LIMIT_EXCEEDED_CODE = 400;
+  private  static final String BILLING_TIER_LIMIT_EXCEEDED_REASON = "billingTierLimitExceeded";
+  private static final Integer NOT_IMPLEMENTED_CODE = 501;
+  @Rule
+  private final ExpectedException exceptionRule = ExpectedException.none();
+  @Mock
+  private DeltaTargetContext deltaTargetContext;
+  @Mock
+  private BigQueryTarget.Conf conf;
+  @Mock
+  private StorageOptions.Builder builder;
+  @Mock
+  private BucketInfo.Builder bucketInfoBuilder;
+  @Mock
+  private Storage storage;
+  @Mock
+  private Credentials credentials;
+  @Mock
+  private BucketInfo bucketInfo;
+  @Mock
+  StorageOptions options;
+  private final DeltaPipelineId pipelineId = new DeltaPipelineId("ns", "app", 1L);
+
+  @Before
+  public void setUp() throws Exception {
+    Mockito.when(deltaTargetContext.getRuntimeArguments()).thenReturn(new HashMap<String, String>() {{
+      put(GCP_CMEK_KEY_NAME, "GCP_CMEK_KEY_NAME");
+    }});
+    PowerMockito.when(conf, "getProject").thenReturn(PROJECT);
+    PowerMockito.when(conf, "getCredentials").thenReturn(credentials);
+    Mockito.when(builder.setCredentials(credentials)).thenReturn(builder);
+    Mockito.when(builder.setProjectId(PROJECT)).thenReturn(builder);
+    PowerMockito.whenNew(StorageOptions.Builder.class).withNoArguments().thenReturn(builder);
+    Mockito.when(deltaTargetContext.getPipelineId()).thenReturn(pipelineId);
+
+  }
 
   @Test
   public void testStagingBucketName() {
     String expectedBucketName = "somebucket";
-    DeltaPipelineId pipelineId = new DeltaPipelineId("ns", "app", 1L);
     Assert.assertEquals(expectedBucketName, BigQueryTarget.getStagingBucketName("somebucket", pipelineId));
     Assert.assertEquals(expectedBucketName, BigQueryTarget.getStagingBucketName("SomeBucket", pipelineId));
     Assert.assertEquals(expectedBucketName, BigQueryTarget.getStagingBucketName("somebucket  ", pipelineId));
@@ -41,4 +113,122 @@ public class BigQueryTargetTest {
     Assert.assertEquals(expectedBucketName, BigQueryTarget.getStagingBucketName("   ", pipelineId));
     Assert.assertEquals(expectedBucketName, BigQueryTarget.getStagingBucketName(null, pipelineId));
   }
+
+  @Test
+  public void testGetMaximumExistingSequenceNumberForRetryableFailures() throws Exception {
+    List<Throwable> exceptions = new ArrayList<>();
+    exceptions.add(new BigQueryException(500, null));
+    exceptions.add(new BigQueryException(BILLING_TIER_LIMIT_EXCEEDED_CODE, null,
+            new BigQueryError(BILLING_TIER_LIMIT_EXCEEDED_REASON, null, null)));
+    exceptions.add(new BigQueryException(RATE_LIMIT_EXCEEDED_CODES.stream().findAny().get(), null,
+            new BigQueryError(RATE_LIMIT_EXCEEDED_REASON, null, null)));
+
+    BigQueryTarget bqTarget = new BigQueryTarget(conf);
+
+    for (Throwable exception: exceptions) {
+      PowerMockito.mockStatic(BigQueryUtils.class);
+      PowerMockito.doThrow(exception).when(BigQueryUtils.class);
+      BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
+              Mockito.nullable(String.class), Mockito.any(BigQuery.class),
+              Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+      try {
+        exceptionRule.expect(exception.getClass());
+        bqTarget.initialize(deltaTargetContext);
+      } finally {
+        //verify at least 1 retry happens
+        PowerMockito.verifyStatic(BigQueryUtils.class, Mockito.atLeast(2));
+        BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
+                Mockito.nullable(String.class), Mockito.any(BigQuery.class),
+                Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+      }
+    }
+  }
+
+  @Test
+  public void testGetMaximumExistingSequenceNumberForNonRetryableFailures() throws Exception {
+    List<Throwable> exceptions = new ArrayList<>();
+    exceptions.add(new BigQueryException(NOT_IMPLEMENTED_CODE, null));
+    exceptions.add(new RuntimeException());
+
+    BigQueryTarget bqTarget = new BigQueryTarget(conf);
+
+    for (Throwable exception: exceptions) {
+      PowerMockito.mockStatic(BigQueryUtils.class);
+      PowerMockito.doThrow(exception).when(BigQueryUtils.class);
+      BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
+              Mockito.nullable(String.class), Mockito.any(BigQuery.class),
+              Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+      try {
+        exceptionRule.expect(exception.getClass());
+        bqTarget.initialize(deltaTargetContext);
+      } finally {
+        //Verify no retries
+        PowerMockito.verifyStatic(BigQueryUtils.class, Mockito.times(1));
+        BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
+                Mockito.nullable(String.class), Mockito.any(BigQuery.class),
+                Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+      }
+    }
+  }
+
+  @Test
+  public void testCreateConsumerRetryableFailureForGcsCreate() throws Exception {
+    Mockito.when(options.getService()).thenReturn(storage);
+    Mockito.when(builder.build()).thenReturn(options);
+
+    PowerMockito.mockStatic(BucketInfo.class);
+    PowerMockito.doReturn(bucketInfoBuilder).when(BucketInfo.class);
+    BucketInfo.newBuilder(Mockito.nullable(String.class));
+    Mockito.when(bucketInfoBuilder.build()).thenReturn(bucketInfo);
+
+    Throwable exception = new StorageException(403, null);
+    Mockito.when(storage.create(Mockito.any(BucketInfo.class))).thenThrow(exception);
+
+    BigQueryTarget bqTarget = new BigQueryTarget(conf);
+    try {
+      //IO Exception thrown is wrapped by Failsafe.Failsafe wraps checked exceptions.
+      exceptionRule.expect(FailsafeException.class);
+      bqTarget.createConsumer(deltaTargetContext);
+    } finally {
+      //Verify at least 1 retry
+      Mockito.verify(storage, Mockito.atLeast(2)).create(Mockito.any(BucketInfo.class));
+    }
+  }
+
+  @Test
+  public void testCreateConsumerRetryableFailureForGcsGet() throws Exception {
+    Mockito.when(options.getService()).thenReturn(storage);
+    Mockito.when(builder.build()).thenReturn(options);
+
+    Throwable exception = new StorageException(500, null);
+    Mockito.when(storage.get(Mockito.anyString())).thenThrow(exception);
+
+    BigQueryTarget bqTarget = new BigQueryTarget(conf);
+    try {
+      exceptionRule.expect(exception.getClass());
+      bqTarget.createConsumer(deltaTargetContext);
+    } finally {
+      //Verify at least 1 retry
+      Mockito.verify(storage, Mockito.atLeast(2)).get(Mockito.nullable(String.class));
+    }
+  }
+
+  @Test
+  public void testCreateConsumerNonRetryableFailure() throws Exception {
+    Mockito.when(options.getService()).thenReturn(storage);
+    Mockito.when(builder.build()).thenReturn(options);
+
+    Throwable exception = new StorageException(501, null);
+    Mockito.when(storage.get(Mockito.anyString())).thenThrow(exception);
+
+    BigQueryTarget bqTarget = new BigQueryTarget(conf);
+    try {
+      exceptionRule.expect(exception.getClass());
+      bqTarget.createConsumer(deltaTargetContext);
+    } finally {
+      //Verify no retry
+      Mockito.verify(storage, Mockito.times(1)).get(Mockito.nullable(String.class));
+    }
+  }
+
 }


### PR DESCRIPTION
- Added retry for BQ call to retrieve maximum existing sequence number and GCS calls to get/create staging buckets.
- Added unit tests

