### PR TITLE
Add retry for BQ calls during plugin initialization 

### DIFF
--- a/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
@@ -20,6 +20,7 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.EncryptionConfiguration;
 import com.google.cloud.storage.Bucket;
@@ -41,6 +42,8 @@ import io.cdap.delta.api.DeltaTargetContext;
 import io.cdap.delta.api.EventConsumer;
 import io.cdap.delta.api.assessment.StandardizedTableDetail;
 import io.cdap.delta.api.assessment.TableAssessor;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +51,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -65,6 +73,10 @@ public class BigQueryTarget implements DeltaTarget {
   private static final String GCS_SCHEME = "gs://";
   private static final String GCP_CMEK_KEY_NAME = "gcp.cmek.key.name";
   private static final int MAX_TABLES_PER_QUERY = 1000;
+  private  static final String RATE_LIMIT_EXCEEDED_REASON = "rateLimitExceeded";
+  private static final Set<Integer> RATE_LIMIT_EXCEEDED_CODES = new HashSet<>(Arrays.asList(400, 403));
+  private  static final int BILLING_TIER_LIMIT_EXCEEDED_CODE = 400;
+  private  static final String BILLING_TIER_LIMIT_EXCEEDED_REASON = "billingTierLimitExceeded";
   private final Conf conf;
 
   @SuppressWarnings("unused")
@@ -93,9 +105,9 @@ public class BigQueryTarget implements DeltaTarget {
       .build()
       .getService();
 
-    long maximumExistingSequenceNumber =
-      BigQueryUtils.getMaximumExistingSequenceNumber(context.getAllTables(), project, conf.getDatasetName(),
-                                                     bigQuery, encryptionConfig, MAX_TABLES_PER_QUERY);
+    long maximumExistingSequenceNumber = Failsafe.with(createRetryPolicyForBq()).get(() ->
+            BigQueryUtils.getMaximumExistingSequenceNumber(context.getAllTables(), project, conf.getDatasetName(),
+                    bigQuery, encryptionConfig, MAX_TABLES_PER_QUERY));
 
     LOG.info("Found maximum sequence number {}", maximumExistingSequenceNumber);
 
@@ -125,30 +137,41 @@ public class BigQueryTarget implements DeltaTarget {
       .getService();
 
     String stagingBucketName = getStagingBucketName(conf.stagingBucket, context.getPipelineId());
-    Bucket bucket = storage.get(stagingBucketName);
-    if (bucket == null) {
-      try {
-        BucketInfo.Builder builder = BucketInfo.newBuilder(stagingBucketName);
-        if (cmekKey != null) {
-          builder.setDefaultKmsKeyName(cmekKey);
+    RetryPolicy<Object> retryPolicy = new RetryPolicy<>()
+            .withMaxAttempts(25)
+            .withMaxDuration(Duration.of(2, ChronoUnit.MINUTES))
+            .withBackoff(1, 30, ChronoUnit.SECONDS)
+            .withJitter(0.1)
+            .abortOn(throwable -> !((throwable instanceof IOException) ||
+                    (throwable instanceof StorageException && ((StorageException) throwable).isRetryable())));
+
+    Bucket bucket = Failsafe.with(retryPolicy).get(() -> {
+      Bucket b = storage.get(stagingBucketName);
+      if (b == null) {
+        try {
+          BucketInfo.Builder builder = BucketInfo.newBuilder(stagingBucketName);
+          if (cmekKey != null) {
+            builder.setDefaultKmsKeyName(cmekKey);
+          }
+          if (conf.stagingBucketLocation != null && !conf.stagingBucketLocation.trim().isEmpty()) {
+            builder.setLocation(conf.stagingBucketLocation);
+          }
+          b = storage.create(builder.build());
+        } catch (StorageException e) {
+          // It is possible that in multiple worker instances scenario
+          // bucket is created by another worker instance after this worker instance
+          // determined that the bucket does not exists. Ignore error if bucket already exists.
+          if (e.getCode() != CONFLICT) {
+            throw new IOException(
+                    String.format("Unable to create staging bucket '%s' in project '%s'. " +
+                            "Please make sure the service account has permission to create buckets, " +
+                            "or create the bucket before starting the program.", stagingBucketName, project), e);
+          }
+          b = storage.get(stagingBucketName);
         }
-        if (conf.stagingBucketLocation != null && !conf.stagingBucketLocation.trim().isEmpty()) {
-          builder.setLocation(conf.stagingBucketLocation);
-        }
-        bucket = storage.create(builder.build());
-      } catch (StorageException e) {
-        // It is possible that in multiple worker instances scenario
-        // bucket is created by another worker instance after this worker instance
-        // determined that the bucket does not exists. Ignore error if bucket already exists.
-        if (e.getCode() != CONFLICT) {
-          throw new IOException(
-            String.format("Unable to create staging bucket '%s' in project '%s'. "
-                            + "Please make sure the service account has permission to create buckets, "
-                            + "or create the bucket before starting the program.", stagingBucketName, project), e);
-        }
-        bucket = storage.get(stagingBucketName);
       }
-    }
+      return b;
+    });
 
     return new BigQueryEventConsumer(context, storage, bigQuery, bucket, project,
                                      conf.getLoadIntervalSeconds(), conf.getStagingTablePrefix(),
@@ -176,6 +199,27 @@ public class BigQueryTarget implements DeltaTarget {
   private static String stringifyPipelineId(DeltaPipelineId pipelineId) {
     return Joiner.on("-").join(STAGING_BUCKET_PREFIX, pipelineId.getNamespace(), pipelineId.getApp(),
                                pipelineId.getGeneration());
+  }
+
+  private <T> RetryPolicy<T> createRetryPolicyForBq() {
+    RetryPolicy<T> retryPolicy = new RetryPolicy<>();
+    retryPolicy.abortOn(throwable -> {
+      if (throwable instanceof BigQueryException) {
+        BigQueryException t = (BigQueryException) throwable;
+        int code = t.getCode();
+        String reason = t.getError() != null ? t.getError().getReason() : null;
+        boolean isRateLimitExceeded =  RATE_LIMIT_EXCEEDED_CODES.contains(code)
+                && RATE_LIMIT_EXCEEDED_REASON.equals(reason);
+        boolean isBillingTierLimitExceeded = code == BILLING_TIER_LIMIT_EXCEEDED_CODE
+                && BILLING_TIER_LIMIT_EXCEEDED_REASON.equals(reason);
+        return !(t.isRetryable() || isRateLimitExceeded || isBillingTierLimitExceeded);
+      }
+      return false;
+    });
+    return retryPolicy.withMaxAttempts(25)
+            .withMaxDuration(Duration.of(2, ChronoUnit.MINUTES))
+            .withBackoff(1, 30, ChronoUnit.SECONDS)
+            .withJitter(0.1);
   }
 
   /**

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryUtils.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryUtils.java
@@ -136,10 +136,12 @@ public final class BigQueryUtils {
       maxSequenceNumber = maxSequenceNumQueryPerTable.size() == 0 ? 0 : executeAggregateQuery(bigQuery,
                                                                                               builder.toString(),
                                                                                               encryptionConfiguration);
-    } catch (Exception e) {
+    } catch (InterruptedException e) {
       throw new RuntimeException("Failed to compute the maximum sequence number among all the target tables " +
-                                   "selected for replication. Please make sure that if target tables exists, " +
-                                   "they should have '_sequence_num' column in them.", e);
+              "selected for replication. Please make sure that if target tables exists, " +
+              "they should have '_sequence_num' column in them.", e);
+    } catch (Exception e) {
+      throw e;
     }
     return maxSequenceNumber;
   }

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryTargetTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryTargetTest.java
@@ -16,21 +16,93 @@
 
 package io.cdap.delta.bigquery;
 
+import com.google.auth.Credentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.EncryptionConfiguration;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.StorageOptions;
 import io.cdap.delta.api.DeltaPipelineId;
+import io.cdap.delta.api.DeltaTargetContext;
+import net.jodah.failsafe.FailsafeException;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+
 
 import static io.cdap.delta.bigquery.BigQueryTarget.STAGING_BUCKET_PREFIX;
 
 /**
  * Tests for BigQueryTarget.
  */
+@PrepareForTest({BigQueryUtils.class, BigQueryTarget.class, StorageOptions.class, BucketInfo.class})
+@RunWith(PowerMockRunner.class)
 public class BigQueryTargetTest {
+
+  private static final String GCP_CMEK_KEY_NAME = "gcp.cmek.key.name";
+  private static final String PROJECT = "project";
+  private  static final String RATE_LIMIT_EXCEEDED_REASON = "rateLimitExceeded";
+  private static final Set<Integer> RATE_LIMIT_EXCEEDED_CODES = new HashSet<>(Arrays.asList(400, 403));
+  private  static final int BILLING_TIER_LIMIT_EXCEEDED_CODE = 400;
+  private  static final String BILLING_TIER_LIMIT_EXCEEDED_REASON = "billingTierLimitExceeded";
+  private static final Integer NOT_IMPLEMENTED_CODE = 501;
+  @Rule
+  private final ExpectedException exceptionRule = ExpectedException.none();
+  @Mock
+  private DeltaTargetContext deltaTargetContext;
+  @Mock
+  private BigQueryTarget.Conf conf;
+  @Mock
+  private StorageOptions.Builder builder;
+  @Mock
+  private BucketInfo.Builder bucketInfoBuilder;
+  @Mock
+  private Storage storage;
+  @Mock
+  private Credentials credentials;
+  @Mock
+  private BucketInfo bucketInfo;
+  @Mock
+  StorageOptions options;
+  private final DeltaPipelineId pipelineId = new DeltaPipelineId("ns", "app", 1L);
+
+  @Before
+  public void setUp() throws Exception {
+    Mockito.when(deltaTargetContext.getRuntimeArguments()).thenReturn(new HashMap<String, String>() {{
+      put(GCP_CMEK_KEY_NAME, "GCP_CMEK_KEY_NAME");
+    }});
+    PowerMockito.when(conf, "getProject").thenReturn(PROJECT);
+    PowerMockito.when(conf, "getCredentials").thenReturn(credentials);
+    Mockito.when(builder.setCredentials(credentials)).thenReturn(builder);
+    Mockito.when(builder.setProjectId(PROJECT)).thenReturn(builder);
+    PowerMockito.whenNew(StorageOptions.Builder.class).withNoArguments().thenReturn(builder);
+    Mockito.when(deltaTargetContext.getPipelineId()).thenReturn(pipelineId);
+
+  }
 
   @Test
   public void testStagingBucketName() {
     String expectedBucketName = "somebucket";
-    DeltaPipelineId pipelineId = new DeltaPipelineId("ns", "app", 1L);
     Assert.assertEquals(expectedBucketName, BigQueryTarget.getStagingBucketName("somebucket", pipelineId));
     Assert.assertEquals(expectedBucketName, BigQueryTarget.getStagingBucketName("SomeBucket", pipelineId));
     Assert.assertEquals(expectedBucketName, BigQueryTarget.getStagingBucketName("somebucket  ", pipelineId));
@@ -41,4 +113,122 @@ public class BigQueryTargetTest {
     Assert.assertEquals(expectedBucketName, BigQueryTarget.getStagingBucketName("   ", pipelineId));
     Assert.assertEquals(expectedBucketName, BigQueryTarget.getStagingBucketName(null, pipelineId));
   }
+
+  @Test
+  public void testGetMaximumExistingSequenceNumberForRetryableFailures() throws Exception {
+    List<Throwable> exceptions = new ArrayList<>();
+    exceptions.add(new BigQueryException(500, null));
+    exceptions.add(new BigQueryException(BILLING_TIER_LIMIT_EXCEEDED_CODE, null,
+            new BigQueryError(BILLING_TIER_LIMIT_EXCEEDED_REASON, null, null)));
+    exceptions.add(new BigQueryException(RATE_LIMIT_EXCEEDED_CODES.stream().findAny().get(), null,
+            new BigQueryError(RATE_LIMIT_EXCEEDED_REASON, null, null)));
+
+    BigQueryTarget bqTarget = new BigQueryTarget(conf);
+
+    for (Throwable exception: exceptions) {
+      PowerMockito.mockStatic(BigQueryUtils.class);
+      PowerMockito.doThrow(exception).when(BigQueryUtils.class);
+      BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
+              Mockito.nullable(String.class), Mockito.any(BigQuery.class),
+              Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+      try {
+        exceptionRule.expect(exception.getClass());
+        bqTarget.initialize(deltaTargetContext);
+      } finally {
+        //verify at least 1 retry happens
+        PowerMockito.verifyStatic(BigQueryUtils.class, Mockito.atLeast(2));
+        BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
+                Mockito.nullable(String.class), Mockito.any(BigQuery.class),
+                Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+      }
+    }
+  }
+
+  @Test
+  public void testGetMaximumExistingSequenceNumberForNonRetryableFailures() throws Exception {
+    List<Throwable> exceptions = new ArrayList<>();
+    exceptions.add(new BigQueryException(NOT_IMPLEMENTED_CODE, null));
+    exceptions.add(new RuntimeException());
+
+    BigQueryTarget bqTarget = new BigQueryTarget(conf);
+
+    for (Throwable exception: exceptions) {
+      PowerMockito.mockStatic(BigQueryUtils.class);
+      PowerMockito.doThrow(exception).when(BigQueryUtils.class);
+      BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
+              Mockito.nullable(String.class), Mockito.any(BigQuery.class),
+              Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+      try {
+        exceptionRule.expect(exception.getClass());
+        bqTarget.initialize(deltaTargetContext);
+      } finally {
+        //Verify no retries
+        PowerMockito.verifyStatic(BigQueryUtils.class, Mockito.times(1));
+        BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
+                Mockito.nullable(String.class), Mockito.any(BigQuery.class),
+                Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+      }
+    }
+  }
+
+  @Test
+  public void testCreateConsumerRetryableFailureForGcsCreate() throws Exception {
+    Mockito.when(options.getService()).thenReturn(storage);
+    Mockito.when(builder.build()).thenReturn(options);
+
+    PowerMockito.mockStatic(BucketInfo.class);
+    PowerMockito.doReturn(bucketInfoBuilder).when(BucketInfo.class);
+    BucketInfo.newBuilder(Mockito.nullable(String.class));
+    Mockito.when(bucketInfoBuilder.build()).thenReturn(bucketInfo);
+
+    Throwable exception = new StorageException(403, null);
+    Mockito.when(storage.create(Mockito.any(BucketInfo.class))).thenThrow(exception);
+
+    BigQueryTarget bqTarget = new BigQueryTarget(conf);
+    try {
+      //IO Exception thrown is wrapped by Failsafe.Failsafe wraps checked exceptions.
+      exceptionRule.expect(FailsafeException.class);
+      bqTarget.createConsumer(deltaTargetContext);
+    } finally {
+      //Verify at least 1 retry
+      Mockito.verify(storage, Mockito.atLeast(2)).create(Mockito.any(BucketInfo.class));
+    }
+  }
+
+  @Test
+  public void testCreateConsumerRetryableFailureForGcsGet() throws Exception {
+    Mockito.when(options.getService()).thenReturn(storage);
+    Mockito.when(builder.build()).thenReturn(options);
+
+    Throwable exception = new StorageException(500, null);
+    Mockito.when(storage.get(Mockito.anyString())).thenThrow(exception);
+
+    BigQueryTarget bqTarget = new BigQueryTarget(conf);
+    try {
+      exceptionRule.expect(exception.getClass());
+      bqTarget.createConsumer(deltaTargetContext);
+    } finally {
+      //Verify at least 1 retry
+      Mockito.verify(storage, Mockito.atLeast(2)).get(Mockito.nullable(String.class));
+    }
+  }
+
+  @Test
+  public void testCreateConsumerNonRetryableFailure() throws Exception {
+    Mockito.when(options.getService()).thenReturn(storage);
+    Mockito.when(builder.build()).thenReturn(options);
+
+    Throwable exception = new StorageException(501, null);
+    Mockito.when(storage.get(Mockito.anyString())).thenThrow(exception);
+
+    BigQueryTarget bqTarget = new BigQueryTarget(conf);
+    try {
+      exceptionRule.expect(exception.getClass());
+      bqTarget.createConsumer(deltaTargetContext);
+    } finally {
+      //Verify no retry
+      Mockito.verify(storage, Mockito.times(1)).get(Mockito.nullable(String.class));
+    }
+  }
+
 }

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryTargetTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryTargetTest.java
@@ -16,17 +16,26 @@
 
 package io.cdap.delta.bigquery;
 
+import com.google.api.gax.paging.Page;
 import com.google.auth.Credentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.EncryptionConfiguration;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.JobStatus;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import io.cdap.delta.api.DeltaPipelineId;
 import io.cdap.delta.api.DeltaTargetContext;
+import io.cdap.delta.api.SourceTable;
 import net.jodah.failsafe.FailsafeException;
 import org.junit.Assert;
 import org.junit.Before;
@@ -42,10 +51,13 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 
 
@@ -55,49 +67,94 @@ import static io.cdap.delta.bigquery.BigQueryTarget.STAGING_BUCKET_PREFIX;
 /**
  * Tests for BigQueryTarget.
  */
-@PrepareForTest({BigQueryUtils.class, BigQueryTarget.class, StorageOptions.class, BucketInfo.class})
+@PrepareForTest({BigQueryUtils.class, BigQueryTarget.class, StorageOptions.class,
+        BucketInfo.class, BigQueryOptions.class})
 @RunWith(PowerMockRunner.class)
 public class BigQueryTargetTest {
-
   private static final String GCP_CMEK_KEY_NAME = "gcp.cmek.key.name";
   private static final String PROJECT = "project";
+  private static final String DATASET = "dataset";
+  private static final String TABLE = "table";
   private  static final String RATE_LIMIT_EXCEEDED_REASON = "rateLimitExceeded";
   private static final Set<Integer> RATE_LIMIT_EXCEEDED_CODES = new HashSet<>(Arrays.asList(400, 403));
   private  static final int BILLING_TIER_LIMIT_EXCEEDED_CODE = 400;
   private  static final String BILLING_TIER_LIMIT_EXCEEDED_REASON = "billingTierLimitExceeded";
   private static final Integer NOT_IMPLEMENTED_CODE = 501;
+  private static final int BQ_JOB_TIME_BOUND = 2;
+  private final DeltaPipelineId pipelineId = new DeltaPipelineId("ns", "app", 1L);
   @Rule
   private final ExpectedException exceptionRule = ExpectedException.none();
+  @Mock
+  private Job job;
   @Mock
   private DeltaTargetContext deltaTargetContext;
   @Mock
   private BigQueryTarget.Conf conf;
   @Mock
-  private StorageOptions.Builder builder;
+  private StorageOptions.Builder storageBuilder;
+  @Mock
+  private BigQueryOptions.Builder bigqueryBuilder;
   @Mock
   private BucketInfo.Builder bucketInfoBuilder;
   @Mock
-  private Storage storage;
-  @Mock
-  private Credentials credentials;
+  private BigQuery bigQuery;
   @Mock
   private BucketInfo bucketInfo;
   @Mock
-  StorageOptions options;
-  private final DeltaPipelineId pipelineId = new DeltaPipelineId("ns", "app", 1L);
+  private Storage storage;
+  @Mock
+  StorageOptions storageOptions;
+  @Mock
+  BigQueryOptions bigqueryOptions;
+  @Mock
+  private Credentials credentials;
+  @Mock
+  private SourceTable sourceTable;
+  @Mock
+  private Table table;
 
   @Before
   public void setUp() throws Exception {
     Mockito.when(deltaTargetContext.getRuntimeArguments()).thenReturn(new HashMap<String, String>() {{
       put(GCP_CMEK_KEY_NAME, "GCP_CMEK_KEY_NAME");
     }});
+    Mockito.when(deltaTargetContext.getPipelineId()).thenReturn(pipelineId);
+    Mockito.when(deltaTargetContext.getAllTables()).thenReturn(new HashSet<SourceTable>() {{ add(sourceTable); }});
+
     PowerMockito.when(conf, "getProject").thenReturn(PROJECT);
     PowerMockito.when(conf, "getCredentials").thenReturn(credentials);
-    Mockito.when(builder.setCredentials(credentials)).thenReturn(builder);
-    Mockito.when(builder.setProjectId(PROJECT)).thenReturn(builder);
-    PowerMockito.whenNew(StorageOptions.Builder.class).withNoArguments().thenReturn(builder);
-    Mockito.when(deltaTargetContext.getPipelineId()).thenReturn(pipelineId);
 
+    Mockito.when(bucketInfoBuilder.build()).thenReturn(bucketInfo);
+
+    Mockito.when(storageOptions.getService()).thenReturn(storage);
+    Mockito.when(storageBuilder.build()).thenReturn(storageOptions);
+    Mockito.when(storageBuilder.setCredentials(credentials)).thenReturn(storageBuilder);
+    Mockito.when(storageBuilder.setProjectId(PROJECT)).thenReturn(storageBuilder);
+    PowerMockito.whenNew(StorageOptions.Builder.class).withNoArguments().thenReturn(storageBuilder);
+
+    Mockito.when(bigqueryOptions.getService()).thenReturn(bigQuery);
+    Mockito.when(bigqueryBuilder.build()).thenReturn(bigqueryOptions);
+    Mockito.when(bigqueryBuilder.setCredentials(credentials)).thenReturn(bigqueryBuilder);
+    Mockito.when(bigqueryBuilder.setProjectId(PROJECT)).thenReturn(bigqueryBuilder);
+    PowerMockito.whenNew(BigQueryOptions.Builder.class).withNoArguments().thenReturn(bigqueryBuilder);
+
+    Mockito.when(sourceTable.getDatabase()).thenReturn(DATASET);
+    Mockito.when(sourceTable.getTable()).thenReturn(TABLE);
+    Mockito.when(table.getTableId()).thenReturn(TableId.of(PROJECT, DATASET, TABLE));
+
+    //Random execution time for BigQuery job
+    Mockito.when(job.waitFor())
+            .thenAnswer((a) -> {
+              TimeUnit.MILLISECONDS.sleep(ThreadLocalRandom.current().nextLong(BQ_JOB_TIME_BOUND));
+              return job;
+            });
+    Mockito.when(job.getStatus()).thenReturn(Mockito.mock(JobStatus.class));
+
+    Mockito.when(bigQuery.getTable(Mockito.any())).thenReturn(table);
+    Mockito.when(bigQuery.getDataset(Mockito.anyString())).thenReturn(Mockito.mock(Dataset.class));
+    Mockito.when(bigQuery.create(Mockito.any(JobInfo.class))).thenReturn(job);
+    Mockito.when(bigQuery.listTables(Mockito.anyString())).thenReturn(Mockito.mock(Page.class));
+    Mockito.when(bigQuery.listTables(Mockito.anyString()).iterateAll()).thenReturn(Collections.singletonList(table));
   }
 
   @Test
@@ -116,23 +173,18 @@ public class BigQueryTargetTest {
 
   @Test
   public void testGetMaximumExistingSequenceNumberForRetryableFailures() throws Exception {
+    PowerMockito.mockStatic(BigQueryUtils.class, Mockito.CALLS_REAL_METHODS);
     List<Throwable> exceptions = new ArrayList<>();
     exceptions.add(new BigQueryException(500, null));
     exceptions.add(new BigQueryException(BILLING_TIER_LIMIT_EXCEEDED_CODE, null,
             new BigQueryError(BILLING_TIER_LIMIT_EXCEEDED_REASON, null, null)));
     exceptions.add(new BigQueryException(RATE_LIMIT_EXCEEDED_CODES.stream().findAny().get(), null,
             new BigQueryError(RATE_LIMIT_EXCEEDED_REASON, null, null)));
-
     BigQueryTarget bqTarget = new BigQueryTarget(conf);
-
     for (Throwable exception: exceptions) {
-      PowerMockito.mockStatic(BigQueryUtils.class);
-      PowerMockito.doThrow(exception).when(BigQueryUtils.class);
-      BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
-              Mockito.nullable(String.class), Mockito.any(BigQuery.class),
-              Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+      Mockito.when(job.getQueryResults()).thenThrow(exception);
       try {
-        exceptionRule.expect(exception.getClass());
+        exceptionRule.expect(RuntimeException.class);
         bqTarget.initialize(deltaTargetContext);
       } finally {
         //verify at least 1 retry happens
@@ -142,24 +194,33 @@ public class BigQueryTargetTest {
                 Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
       }
     }
+    //verify when list tables() throws exception
+    Mockito.when(bigQuery.listTables(Mockito.anyString())).thenThrow(
+                    new BigQueryException(BILLING_TIER_LIMIT_EXCEEDED_CODE, null,
+                    new BigQueryError(BILLING_TIER_LIMIT_EXCEEDED_REASON, null, null)));
+    try {
+      exceptionRule.expect(RuntimeException.class);
+      bqTarget.initialize(deltaTargetContext);
+    } finally {
+      //verify at least 1 retry happens
+      PowerMockito.verifyStatic(BigQueryUtils.class, Mockito.atLeast(2));
+      BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
+              Mockito.nullable(String.class), Mockito.any(BigQuery.class),
+              Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+    }
   }
 
   @Test
   public void testGetMaximumExistingSequenceNumberForNonRetryableFailures() throws Exception {
+    PowerMockito.mockStatic(BigQueryUtils.class, Mockito.CALLS_REAL_METHODS);
     List<Throwable> exceptions = new ArrayList<>();
     exceptions.add(new BigQueryException(NOT_IMPLEMENTED_CODE, null));
     exceptions.add(new RuntimeException());
-
     BigQueryTarget bqTarget = new BigQueryTarget(conf);
-
     for (Throwable exception: exceptions) {
-      PowerMockito.mockStatic(BigQueryUtils.class);
-      PowerMockito.doThrow(exception).when(BigQueryUtils.class);
-      BigQueryUtils.getMaximumExistingSequenceNumber(Mockito.anySet(), Mockito.anyString(),
-              Mockito.nullable(String.class), Mockito.any(BigQuery.class),
-              Mockito.nullable(EncryptionConfiguration.class), Mockito.anyInt());
+      Mockito.when(job.getQueryResults()).thenThrow(exception);
       try {
-        exceptionRule.expect(exception.getClass());
+        exceptionRule.expect(RuntimeException.class);
         bqTarget.initialize(deltaTargetContext);
       } finally {
         //Verify no retries
@@ -173,13 +234,9 @@ public class BigQueryTargetTest {
 
   @Test
   public void testCreateConsumerRetryableFailureForGcsCreate() throws Exception {
-    Mockito.when(options.getService()).thenReturn(storage);
-    Mockito.when(builder.build()).thenReturn(options);
-
     PowerMockito.mockStatic(BucketInfo.class);
     PowerMockito.doReturn(bucketInfoBuilder).when(BucketInfo.class);
     BucketInfo.newBuilder(Mockito.nullable(String.class));
-    Mockito.when(bucketInfoBuilder.build()).thenReturn(bucketInfo);
 
     Throwable exception = new StorageException(403, null);
     Mockito.when(storage.create(Mockito.any(BucketInfo.class))).thenThrow(exception);
@@ -197,8 +254,6 @@ public class BigQueryTargetTest {
 
   @Test
   public void testCreateConsumerRetryableFailureForGcsGet() throws Exception {
-    Mockito.when(options.getService()).thenReturn(storage);
-    Mockito.when(builder.build()).thenReturn(options);
 
     Throwable exception = new StorageException(500, null);
     Mockito.when(storage.get(Mockito.anyString())).thenThrow(exception);
@@ -215,9 +270,6 @@ public class BigQueryTargetTest {
 
   @Test
   public void testCreateConsumerNonRetryableFailure() throws Exception {
-    Mockito.when(options.getService()).thenReturn(storage);
-    Mockito.when(builder.build()).thenReturn(options);
-
     Throwable exception = new StorageException(501, null);
     Mockito.when(storage.get(Mockito.anyString())).thenThrow(exception);
 

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryTargetTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryTargetTest.java
@@ -242,12 +242,10 @@ public class BigQueryTargetTest {
     PowerMockito.doReturn(bucketInfoBuilder).when(BucketInfo.class);
     BucketInfo.newBuilder(Mockito.nullable(String.class));
 
-    Throwable exception = new StorageException(403, null);
+    Throwable exception = new StorageException(408, null);
     Mockito.when(storage.create(Mockito.any(BucketInfo.class))).thenThrow(exception);
-
     try {
-      //IO Exception thrown is wrapped by Failsafe.Failsafe wraps checked exceptions.
-      exceptionRule.expect(FailsafeException.class);
+      exceptionRule.expect(RuntimeException.class);
       bqTarget.createConsumer(deltaTargetContext);
     } finally {
       //Verify at least 1 retry
@@ -257,12 +255,10 @@ public class BigQueryTargetTest {
 
   @Test
   public void testCreateConsumerRetryableFailureForGcsGet() throws Exception {
-
     Throwable exception = new StorageException(500, null);
     Mockito.when(storage.get(Mockito.anyString())).thenThrow(exception);
-
     try {
-      exceptionRule.expect(exception.getClass());
+      exceptionRule.expect(RuntimeException.class);
       bqTarget.createConsumer(deltaTargetContext);
     } finally {
       //Verify at least 1 retry
@@ -274,9 +270,8 @@ public class BigQueryTargetTest {
   public void testCreateConsumerNonRetryableFailure() throws Exception {
     Throwable exception = new StorageException(501, null);
     Mockito.when(storage.get(Mockito.anyString())).thenThrow(exception);
-
     try {
-      exceptionRule.expect(exception.getClass());
+      exceptionRule.expect(RuntimeException.class);
       bqTarget.createConsumer(deltaTargetContext);
     } finally {
       //Verify no retry


### PR DESCRIPTION
- Added retry for BQ call to retrieve maximum existing sequence number and GCS calls to get/create staging buckets.
- Added unit tests

