### PR TITLE
[Plugin-1703] Support chinese column names

### DIFF
--- a/docs/bigquery-cdcTarget.md
+++ b/docs/bigquery-cdcTarget.md
@@ -82,6 +82,19 @@ name is same as source database name. A valid name should only contain letters, 
 maximum length can be 1024. Any invalid chars would be replaced with underscore in the final dataset name and
 any characters exceeds length limit will be truncated.
 
+**Allow Flexible Column Naming**:
+By default ony english letters, numbers and underscore are allowed in column names. If this option is enabled,
+international characters are also allowed in column names with some extra special characters, which follow the
+bigquery naming convention for flexible column names.
+Some special characters allowed in flexible column names are: 
+- An ampersand (&)
+- A percent sign (%)
+- A colon (:)
+- A lessthan sign (<)
+- A space ( )
+
+Read more about this option [here](https://cloud.google.com/bigquery/docs/schemas#flexible-column-names).
+
 **Encryption Key Name**: GCP Customer-managed encryption key (CMEK) used to encrypt the resources created by this target. 
 Encryption key name should be of the form "projects/<gcp-project-id>/locations/<key-location>/keyRings/<key-ring-name>/cryptoKeys/<key-name>".
 

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryAssessor.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryAssessor.java
@@ -45,11 +45,13 @@ public class BigQueryAssessor implements TableAssessor<StandardizedTableDetail> 
   // tables already assessed so far, key is table name and value is schema name
   private final Map<String, String> tableToSchema;
   private final String datasetName;
+  private final boolean allowFlexibleColumnNaming;
 
-  BigQueryAssessor(String stagingTablePrefix, String datasetName) {
+  BigQueryAssessor(String stagingTablePrefix, String datasetName, boolean allowFlexibleColumnNaming) {
     this.stagingTablePrefix = stagingTablePrefix;
     this.tableToSchema  = new HashMap<>();
     this.datasetName = datasetName;
+    this.allowFlexibleColumnNaming = allowFlexibleColumnNaming;
   }
 
   @Override
@@ -58,7 +60,8 @@ public class BigQueryAssessor implements TableAssessor<StandardizedTableDetail> 
     for (Schema.Field field : tableDetail.getSchema().getFields()) {
       try {
         String bqType = toBigQueryType(field);
-        columnAssessments.add(ColumnAssessment.builder(BigQueryUtils.normalizeFieldName(field.getName()), bqType)
+        columnAssessments.add(ColumnAssessment.builder(BigQueryUtils.normalizeFieldName(field.getName(),
+                        allowFlexibleColumnNaming), bqType)
           .setSourceColumn(field.getName()).build());
         if (LOG.isDebugEnabled()) {
           LOG.debug("Converting schema {} to {}", field.getSchema().isNullable() ?

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryTarget.java
@@ -211,7 +211,7 @@ public class BigQueryTarget implements DeltaTarget {
     return new BigQueryEventConsumer(context, storage, bigQuery, bucket, datasetProject,
                                      conf.getLoadIntervalSeconds(), conf.getStagingTablePrefix(),
                                      conf.requiresManualDrops(), encryptionConfig, null, conf.getDatasetName(),
-                                     conf.softDeletesEnabled());
+                                     conf.softDeletesEnabled(), conf.getAllowFlexibleColumnNaming());
   }
 
   @VisibleForTesting
@@ -228,7 +228,7 @@ public class BigQueryTarget implements DeltaTarget {
 
   @Override
   public TableAssessor<StandardizedTableDetail> createTableAssessor(Configurer configurer) {
-    return new BigQueryAssessor(conf.stagingTablePrefix, conf.datasetName);
+    return new BigQueryAssessor(conf.stagingTablePrefix, conf.datasetName, conf.getAllowFlexibleColumnNaming());
   }
 
   private static String stringifyPipelineId(DeltaPipelineId pipelineId) {
@@ -339,12 +339,28 @@ public class BigQueryTarget implements DeltaTarget {
 
     @Nullable
     @Description(
+      "By default, the target table's column names mirror those of the source table. They are normalized to include " +
+      "only letters, numbers, and underscores. Any invalid characters are replaced with underscores in the " +
+      "final column name. If set to true, the target table's column names will be adjusted to adhere to BigQuery's " +
+      "flexible column naming conventions, such as supporting international characters, spaces, and some more " +
+      "special characters (check docs) with a maximum length of 300 characters. Any invalid characters will " +
+      "be replaced with underscores in the final column name. Additionally, any characters exceeding the length " +
+      "limit will be truncated."
+    )
+    private Boolean allowFlexibleColumnNaming;
+
+    @Nullable
+    @Description(
       "Optional. GCP Customer-managed encryption key (CMEK) used to encrypt the resources created by this target.")
     private String encryptionKeyName;
 
     @Nullable
     public String getDatasetName() {
       return datasetName;
+    }
+
+    public boolean getAllowFlexibleColumnNaming() {
+       return allowFlexibleColumnNaming != null && allowFlexibleColumnNaming;
     }
 
     @Nullable

--- a/src/main/java/io/cdap/delta/bigquery/MultiGCSWriter.java
+++ b/src/main/java/io/cdap/delta/bigquery/MultiGCSWriter.java
@@ -45,6 +45,7 @@ import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -54,6 +55,7 @@ import javax.annotation.Nullable;
 public class MultiGCSWriter {
   private static final Logger LOG = LoggerFactory.getLogger(MultiGCSWriter.class);
   private static final Gson GSON = new Gson();
+  private static final String ENGLISH_CHARACTERS_REGEX = "[\\w]+";
   private final Storage storage;
   private final String bucket;
   private final String baseObjectName;
@@ -114,6 +116,12 @@ public class MultiGCSWriter {
       Schema.LogicalType logicalType
         = isNullable ? field.getSchema().getNonNullable().getLogicalType() : field.getSchema().getLogicalType();
       if (logicalType != null && logicalType.equals(Schema.LogicalType.DATETIME)) {
+        return true;
+      }
+      // If the field name is not in english characters, then we will use json format
+      // We do this as the avro load job in BQ does not support non-english characters in field names for now
+      String fieldName = field.getName();
+      if (!Pattern.matches(ENGLISH_CHARACTERS_REGEX, fieldName)) {
         return true;
       }
     }

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryAssessorTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryAssessorTest.java
@@ -30,7 +30,7 @@ import static com.google.common.collect.Iterators.getOnlyElement;
 public class BigQueryAssessorTest {
   @Test
   public void testAssessTable_duplicatedTableName() {
-    BigQueryAssessor assessor = new BigQueryAssessor("staging_prefix", null);
+    BigQueryAssessor assessor = new BigQueryAssessor("staging_prefix", null, false);
     String dbName = "testDB";
     String tableName = "tableName";
     String schemaName1 = "schemaName1";

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerTest.java
@@ -179,7 +179,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_SECONDS, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -226,7 +226,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_SECONDS, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
     try {
       eventConsumer.start();
 
@@ -281,7 +281,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_SECONDS, "_staging",
                                                                     false, null, 2L,
-                                                                    EMPTY_DATASET_NAME, false);
+                                                                    EMPTY_DATASET_NAME, false, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -317,7 +317,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
                                                                     false, null, 2L,
-                                                                    EMPTY_DATASET_NAME, false);
+                                                                    EMPTY_DATASET_NAME, false, false);
     eventConsumer.start();
 
     generateInsertEvents(eventConsumer, tables, numInsertEvents, CDC);
@@ -359,7 +359,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
     try {
       eventConsumer.start();
 
@@ -409,7 +409,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
 
     try {
       exceptionRule.expect(IllegalStateException.class);
@@ -460,7 +460,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -522,7 +522,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -584,7 +584,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -646,7 +646,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -699,7 +699,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
     eventConsumer.start();
 
     generateDDL(eventConsumer, tables);
@@ -734,7 +734,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
     eventConsumer.start();
     try {
       exceptionRule.expect(DeltaFailureException.class);
@@ -759,7 +759,7 @@ public class BigQueryConsumerTest {
                                                                     bigQuery, bucket, "project",
                                                                     LOAD_INTERVAL_ONE_SECOND, "_staging",
                                                                     false, null, 2L,
-                                                                    DATASET, false);
+                                                                    DATASET, false, false);
     eventConsumer.start();
 
     ExecutorService executorService = Executors.newFixedThreadPool(1);

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerUnorderedSourceTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryConsumerUnorderedSourceTest.java
@@ -156,7 +156,7 @@ public class BigQueryConsumerUnorderedSourceTest {
     String dataset = "unordered_scenario_1";
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(context, storage, bigQuery, bucket,
             project, 1, STAGING_TABLE_PREFIX, false, null, null,
-            dataset, false);
+            dataset, false, false);
     List<String> tableNames = Arrays.asList("users1", "users2");
     try {
       long sequenceNum = createDatasetAndTable(eventConsumer, dataset, tableNames);
@@ -283,7 +283,7 @@ public class BigQueryConsumerUnorderedSourceTest {
   public void testConcurrentUpdateEventsWithoutSnapshot() throws Exception {
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(context, storage, bigQuery, bucket,
             project, 1, STAGING_TABLE_PREFIX, false, null, null,
-            null, false);
+            null, false, false);
     String dataset = "unordered_scenario_2";
     List<String> tableNames = Arrays.asList("users1", "users2");
     try {
@@ -397,7 +397,7 @@ public class BigQueryConsumerUnorderedSourceTest {
     String dataset = "unordered_scenario_3";
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(context, storage, bigQuery, bucket,
             project, 0, STAGING_TABLE_PREFIX, false, null, null,
-            dataset, false);
+            dataset, false, false);
     List<String> tableNames = Arrays.asList("users1", "users2");
     try {
       long sequenceNum = createDatasetAndTable(eventConsumer, dataset, tableNames);

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryEventConsumerTest.java
@@ -148,7 +148,8 @@ public class BigQueryEventConsumerTest {
     runtimeArguments.put("gcp.bigquery.max.clustering.columns", "4");
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(new MockContext(300, runtimeArguments), storage,
                                                                     bigQuery, bucket, project, 0, STAGING_TABLE_PREFIX,
-                                                                    true, null, 1L, null, false);
+                                                                    true, null, 1L, null, false,
+            false);
     String dataset = "testTableCreationWithClustering";
     String tableName = "users";
     List<String> primaryKeys = new ArrayList<>();
@@ -193,7 +194,7 @@ public class BigQueryEventConsumerTest {
     runtimeArguments.put("gcp.bigquery.max.clustering.columns", "4");
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(new MockContext(300, runtimeArguments), storage,
             bigQuery, bucket, project, 0, STAGING_TABLE_PREFIX,
-            true, null, 1L, null, false);
+            true, null, 1L, null, false, false);
     String dataset = "testTableCreationWithClustering_" + UUID.randomUUID().toString().replaceAll("-", "_");
     String tableName = "users";
     List<String> primaryKeys = new ArrayList<>();
@@ -211,7 +212,7 @@ public class BigQueryEventConsumerTest {
     TableId tableId = TableId.of(dataset, tableName);
 
     StandardTableDefinition tableDefinition = StandardTableDefinition.newBuilder()
-            .setSchema(Schemas.convert(schema))
+            .setSchema(Schemas.convert(schema, false))
             .build();
     TableInfo.Builder builder = TableInfo.newBuilder(tableId, tableDefinition);
     TableInfo tableInfo = builder.build();
@@ -243,7 +244,8 @@ public class BigQueryEventConsumerTest {
     Bucket bucket = storage.create(BucketInfo.of(bucketName));
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(new MockContext(300, Collections.emptyMap()),
                                                                     storage, bigQuery, bucket, project, 0,
-                                                                    STAGING_TABLE_PREFIX, true, null, 1L, null, false);
+                                                                    STAGING_TABLE_PREFIX, true, null, 1L, null, false,
+            false);
 
     String dataset = "testInvalidTypesForClustering";
     String allinvalidsTableName = "allinvalids";
@@ -320,7 +322,8 @@ public class BigQueryEventConsumerTest {
 
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(new MockContext(300, new HashMap()), storage,
                                                                     bigQuery, bucket, project, 0, STAGING_TABLE_PREFIX,
-                                                                    true, null, 1L, null, false);
+                                                                    true, null, 1L, null, false,
+            false);
 
     String dataset = "testManualDropRetries";
     String tableName = "users";
@@ -364,7 +367,7 @@ public class BigQueryEventConsumerTest {
 
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(MockContext.INSTANCE, storage, bigQuery, bucket,
                                                                     project, 0, STAGING_TABLE_PREFIX, true, null, null,
-                                                                    null, false);
+                                                                    null, false, false);
 
     String dataset = "testManualDrops";
     String tableName = "users";
@@ -435,7 +438,7 @@ public class BigQueryEventConsumerTest {
 
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(MockContext.INSTANCE, storage, bigQuery, bucket,
                                                                     project, 0, STAGING_TABLE_PREFIX, false, null, null,
-                                                                    null, false);
+                                                                    null, false, false);
 
     String dataset = "testAlter";
     String tableName = "users";
@@ -495,7 +498,7 @@ public class BigQueryEventConsumerTest {
 
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(MockContext.INSTANCE, storage, bigQuery, bucket,
                                                                     project, 0, STAGING_TABLE_PREFIX, false, null, null,
-                                                                    null, false);
+                                                                    null, false, false);
 
     String dataset = "testInsertUpdateDelete";
     try {
@@ -512,7 +515,7 @@ public class BigQueryEventConsumerTest {
 
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(MockContext.INSTANCE, storage, bigQuery, bucket,
                                                                     project, 0, STAGING_TABLE_PREFIX, false, null, null,
-                                                                    null, false);
+                                                                    null, false, false);
 
     String dataset = "testInsertTruncate";
     try {
@@ -529,7 +532,7 @@ public class BigQueryEventConsumerTest {
 
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(MockContext.INSTANCE, storage, bigQuery, bucket,
                                                                     project, 0, STAGING_TABLE_PREFIX, false, null, null,
-                                                                    null, true);
+                                                                    null, true, false);
 
     String dataset = "testInsertUpdateSoftDelete";
     try {
@@ -545,7 +548,7 @@ public class BigQueryEventConsumerTest {
     Bucket bucket = storage.create(BucketInfo.of(bucketName));
     BigQueryEventConsumer eventConsumer = new BigQueryEventConsumer(MockContext.INSTANCE, storage, bigQuery, bucket,
                                                                     project, 0, STAGING_TABLE_PREFIX, false, null, null,
-                                                                    null, false);
+                                                                    null, false, false);
 
     String dataset = "testSchemaNormalization";
     String tableName = "test_table";

--- a/src/test/java/io/cdap/delta/bigquery/BigQueryUtilsTest.java
+++ b/src/test/java/io/cdap/delta/bigquery/BigQueryUtilsTest.java
@@ -153,23 +153,113 @@ public class BigQueryUtilsTest {
 
     @Test
     public void testNormalizeFieldName() {
+      int maxColumnNameLength = 300;
+      String prefix = "_";
       // only contains number and letter
-      assertEquals("a2fs", BigQueryUtils.normalizeFieldName("a2fs"));
+      assertEquals("a2fs", BigQueryUtils.normalizeFieldName("a2fs", false));
       // only contains number and letter start with number
-      assertEquals("_2fas", BigQueryUtils.normalizeFieldName("2fas"));
-      // only contains number and letter and length is 128
-      String name = Strings.repeat("a1", 64);
-      assertEquals(name, BigQueryUtils.normalizeFieldName(name));
-      // only contains number and letter, starts with number and length is 128
-      name = Strings.repeat("1a", 64);
-      assertEquals("_" + name.substring(0, 127), BigQueryUtils.normalizeFieldName(name));
+      assertEquals("_2fas", BigQueryUtils.normalizeFieldName("2fas", false));
+      // only contains number and letter and length is 300
+      String name = Strings.repeat("a1", 150);
+      assertEquals(name, BigQueryUtils.normalizeFieldName(name, false));
+      // only contains number and letter, starts with number and length is 300
+      name = Strings.repeat("1a", 150);
+      assertEquals(prefix + name.substring(0, maxColumnNameLength - prefix.length()),
+              BigQueryUtils.normalizeFieldName(name, false));
       // only contains number and letter and length is 130
-      name = Strings.repeat("a1", 65);
-      assertEquals(name.substring(0, 128), BigQueryUtils.normalizeFieldName(name));
+      name = Strings.repeat("a1", 151);
+      assertEquals(name.substring(0, maxColumnNameLength), BigQueryUtils.normalizeFieldName(name, false));
       // contains invalid character
-      assertEquals("ab_c", BigQueryUtils.normalizeFieldName("ab?/c"));
+      assertEquals("ab_c", BigQueryUtils.normalizeFieldName("ab?/c", false));
       // contains space
-      assertEquals("a2_fs", BigQueryUtils.normalizeFieldName("a2 fs"));
+      assertEquals("a2_fs", BigQueryUtils.normalizeFieldName("a2 fs", false));
+      // contains hyphen
+      assertEquals("a2-fs", BigQueryUtils.normalizeFieldName("a2-fs", true));
+      // contains chinese character
+      assertEquals("你好世界", BigQueryUtils.normalizeFieldName("你好世界", true));
+      // contains japanese character
+      assertEquals("こんにちは世界", BigQueryUtils.normalizeFieldName("こんにちは世界", true));
+      // contains emoji
+      assertEquals("_", BigQueryUtils.normalizeFieldName("👍", true));
+
+      // Testing valid characters
+
+      // underscore is a valid character
+      assertEquals("valid_", BigQueryUtils.normalizeFieldName("valid_", true));
+      // space is a valid character
+      assertEquals("Space is valid", BigQueryUtils.normalizeFieldName("Space is valid", true));
+      // ampersand is valid
+      assertEquals("ampersand&", BigQueryUtils.normalizeFieldName("ampersand&", true));
+      // percent is valid and not replaced
+      assertEquals("percent%", BigQueryUtils.normalizeFieldName("percent%", true));
+      // equals is valid and not replaced
+      assertEquals("equals=", BigQueryUtils.normalizeFieldName("equals=", true));
+      // plus is valid and not replaced
+      assertEquals("plus+", BigQueryUtils.normalizeFieldName("plus+", true));
+      // colon is valid and not replaced
+      assertEquals("colon:", BigQueryUtils.normalizeFieldName("colon:", true));
+      // apostrophe is valid and not replaced
+      assertEquals("apostrophe'", BigQueryUtils.normalizeFieldName("apostrophe'", true));
+      // less than is valid and not replaced
+      assertEquals("less_than<", BigQueryUtils.normalizeFieldName("less_than<", true));
+      // greater than is valid and not replaced
+      assertEquals("greater_than>", BigQueryUtils.normalizeFieldName("greater_than>", true));
+      // number sign is valid and not replaced
+      assertEquals("number_sign#", BigQueryUtils.normalizeFieldName("number_sign#", true));
+      // vertical line is valid and not replaced
+      assertEquals("vertical_line|", BigQueryUtils.normalizeFieldName("vertical_line|", true));
+
+      // Testing invalid characters
+
+      // test for tab
+      assertEquals("tab_", BigQueryUtils.normalizeFieldName("tab\t", true));
+      // exclamation is replaced with underscore
+      assertEquals("exclamation_", BigQueryUtils.normalizeFieldName("exclamation!", true));
+      // quotation is replaced with underscore
+      assertEquals("quotation_", BigQueryUtils.normalizeFieldName("quotation\"", true));
+      // dollar is replaced with underscore
+      assertEquals("dollar_", BigQueryUtils.normalizeFieldName("dollar$", true));
+      // left parenthesis is replaced with underscore
+      assertEquals("left_parenthesis_", BigQueryUtils.normalizeFieldName("left_parenthesis(", true));
+      // right parenthesis is replaced with underscore
+      assertEquals("right_parenthesis_", BigQueryUtils.normalizeFieldName("right_parenthesis)", true));
+      // asterisk is replaced with underscore
+      assertEquals("asterisk_", BigQueryUtils.normalizeFieldName("asterisk*", true));
+      // comma is replaced with underscore
+      assertEquals("comma_", BigQueryUtils.normalizeFieldName("comma,", true));
+      // period is replaced with underscore
+      assertEquals("period_", BigQueryUtils.normalizeFieldName("period.", true));
+      // slash is replaced with underscore
+      assertEquals("slash_", BigQueryUtils.normalizeFieldName("slash/", true));
+      // semicolon is replaced with underscore
+      assertEquals("semicolon_", BigQueryUtils.normalizeFieldName("semicolon;", true));
+      // question mark is replaced with underscore
+      assertEquals("question_mark_", BigQueryUtils.normalizeFieldName("question_mark?", true));
+      // at sign is replaced with underscore
+      assertEquals("at_sign_", BigQueryUtils.normalizeFieldName("at_sign@", true));
+      // left square bracket is replaced with underscore
+      assertEquals("left_square_bracket_", BigQueryUtils.normalizeFieldName("left_square_bracket[", true));
+      // backslash is replaced with underscore
+      assertEquals("backslash_", BigQueryUtils.normalizeFieldName("backslash\\", true));
+      // right square bracket is replaced with underscore
+      assertEquals("right_square_bracket_", BigQueryUtils.normalizeFieldName("right_square_bracket]", true));
+      // circumflex accent is replaced with underscore
+      assertEquals("circumflex_accent_", BigQueryUtils.normalizeFieldName("circumflex_accent^", true));
+      // grave accent is replaced with underscore
+      assertEquals("grave_accent_", BigQueryUtils.normalizeFieldName("grave_accent`", true));
+      // left curly bracket is replaced with underscore
+      assertEquals("left_curly_bracket_", BigQueryUtils.normalizeFieldName("left_curly_bracket{", true));
+      // right curly bracket is replaced with underscore
+      assertEquals("right_curly_bracket_", BigQueryUtils.normalizeFieldName("right_curly_bracket}", true));
+      // tilde is replaced with underscore
+      assertEquals("tilde_", BigQueryUtils.normalizeFieldName("tilde~", true));
+
+      // mixed valid and invalid characters
+      assertEquals("mixed%valid_invalid_", BigQueryUtils.normalizeFieldName("mixed%valid?invalid@", true));
+
+      // test for 2 space
+      assertEquals("a2  fs", BigQueryUtils.normalizeFieldName("a2  fs", true));
+
     }
 
     @Test

--- a/widgets/bigquery-cdcTarget.json
+++ b/widgets/bigquery-cdcTarget.json
@@ -47,6 +47,22 @@
           "widget-type": "textbox"
         },
         {
+          "name": "allowFlexibleColumnNaming",
+            "label": "Allow Flexible Column Naming",
+            "widget-type": "toggle",
+            "widget-attributes": {
+              "default": "false",
+              "on": {
+                "value": "true",
+                "label": "Yes"
+              },
+              "off": {
+                "value": "false",
+                "label": "No"
+              }
+            }
+        },
+        {
           "widget-type": "textbox",
           "label": "Encryption Key Name",
           "name": "encryptionKeyName",


### PR DESCRIPTION
## Support for Chinese character in column names [ Bug Fix ]

Jira : [Plugin-1703](https://cdap.atlassian.net/browse/PLUGIN-1703)

### Changes
- Enabled extended character support for field/column names.
- As per docs max column name can now be 300
- New regex for valid and invalid field/column names.
- Update function `isJsonFormat` to return true when non English character is used
   -  We do this as the avro load job in BQ does not support non-english characters in field names for now
   
### UI Field
- A new ui field is added (false by default) to maintain backwards compatibility, where users can trigger old mappings. 
<img width="307" alt="image" src="https://github.com/data-integrations/bigquery-delta-plugins/assets/122770897/43251ede-ca86-476c-b20b-2137bebe7d6a">


### Unit Test 
- Ran old unit test as validation
![image](https://github.com/data-integrations/bigquery-delta-plugins/assets/122770897/0a5e0327-6556-4adc-8c07-f486725cd9dd)

- Extended test cases with
  - Contains hyphen 
  - Contains Chinese character 
  - Contains Japanese character
  - Contains Emoji 
