### PR TITLE
Upgrade avro to 1.11.3 to fix CVE-2023-39410

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
   </scm>
 
   <properties>
-    <avro.version>1.8.2</avro.version>
+    <avro.version>1.11.3</avro.version>
     <bigquery.version>1.133.1</bigquery.version>
     <cdap.version>6.4.0</cdap.version>
     <delta.version>0.9.0</delta.version>

--- a/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
+++ b/src/main/java/io/cdap/delta/bigquery/BigQueryEventConsumer.java
@@ -16,7 +16,6 @@
 
 package io.cdap.delta.bigquery;
 
-import avro.shaded.com.google.common.collect.ImmutableList;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.BigQueryException;
@@ -42,6 +41,7 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.Storage;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.schema.Schema;


### PR DESCRIPTION
This PR upgrades avro to 1.11.3 to remediate CVE-2023-39410. It also updates the import of ImmutableList in BigQueryEventConsumer.java to standard Guava import, as the shaded avro package does not exist in 1.11.3.